### PR TITLE
fix(cleanup): remove 404 pages and paginate Qdrant orphan cleanup

### DIFF
--- a/content-processor.ts
+++ b/content-processor.ts
@@ -609,6 +609,11 @@ export class ContentProcessor {
                             logger.debug(`HEAD returned ${headStatus} for ${url}, skipping`);
                             if (headStatus === 404) {
                                 notFoundUrls.add(url);
+                                // The URL was optimistically added to visitedUrls when
+                                // dequeued (before we knew it was dead). Remove it so the
+                                // obsolete-chunk cleanup treats it as gone and purges its
+                                // chunks — otherwise deleted pages linger forever.
+                                visitedUrls.delete(normalizedUrl);
                             }
                             skippedCount++;
                             continue;
@@ -768,6 +773,11 @@ export class ContentProcessor {
                     }
 
                     if (status === 404) {
+                        notFoundUrls.add(url);
+                        // The URL was optimistically added to visitedUrls when dequeued
+                        // (before this GET revealed it's a 404). Remove it so the
+                        // obsolete-chunk cleanup treats it as gone and purges its chunks.
+                        visitedUrls.delete(normalizedUrl);
                         const sources = referrers.get(url) ?? new Set([baseUrl]);
                         for (const source of sources) {
                             addBrokenLink(source, url);

--- a/database.ts
+++ b/database.ts
@@ -512,41 +512,54 @@ export class DatabaseManager {
     static async removeObsoleteChunksQdrant(db: QdrantDB, visitedUrls: Set<string>, urlPrefix: string, logger: Logger) {
         const { client, collectionName } = db;
         try {
-            // Get all points that match the URL prefix but are not metadata points
-            const response = await client.scroll(collectionName, {
-                limit: 10000,
-                with_payload: true,
-                with_vector: false,
-                filter: {
-                    must: [
-                        {
-                            key: "url",
-                            match: {
-                                text: urlPrefix
-                            }
+            // Scroll through ALL points that match the URL prefix but are not
+            // metadata points. Qdrant caps a single scroll at its page limit, so
+            // we must paginate via next_page_offset — otherwise large collections
+            // (e.g. tens of thousands of chunks) would only have their first page
+            // examined and obsolete chunks beyond it would never be removed.
+            const filter = {
+                must: [
+                    {
+                        key: "url",
+                        match: {
+                            text: urlPrefix
                         }
-                    ],
-                    must_not: [
-                        {
-                            key: "is_metadata",
-                            match: {
-                                value: true
-                            }
+                    }
+                ],
+                must_not: [
+                    {
+                        key: "is_metadata",
+                        match: {
+                            value: true
                         }
-                    ]
-                }
-            });
+                    }
+                ]
+            };
 
-            const obsoletePointIds = response.points
-                .filter((point: any) => {
+            const obsoletePointIds: any[] = [];
+            let offset: any = undefined;
+            do {
+                const response = await client.scroll(collectionName, {
+                    limit: 1000,
+                    offset,
+                    with_payload: true,
+                    with_vector: false,
+                    filter
+                });
+
+                for (const point of response.points) {
                     const url = point.payload?.url;
                     // Double check it's not a metadata record
                     if (point.payload?.is_metadata === true) {
-                        return false;
+                        continue;
                     }
-                    return url && !visitedUrls.has(url);
-                })
-                .map((point: any) => point.id);
+                    if (url && !visitedUrls.has(url)) {
+                        obsoletePointIds.push(point.id);
+                    }
+                }
+
+                offset = response.next_page_offset;
+            } while (offset !== null && offset !== undefined);
 
             if (obsoletePointIds.length > 0) {
                 await client.delete(collectionName, {

--- a/doc2vec.ts
+++ b/doc2vec.ts
@@ -571,18 +571,34 @@ export class Doc2Vec {
 
         logger.section('CLEANUP');
 
-        // Remove 404 URLs from the Postgres markdown store
-        if (useMarkdownStore && crawlResult.notFoundUrls && crawlResult.notFoundUrls.size > 0) {
-            logger.info(`Removing ${crawlResult.notFoundUrls.size} not-found URLs from markdown store`);
+        // Remove URLs that returned 404 during the crawl. A 404 is a definitive
+        // "this page is gone" signal (network errors fall through to full
+        // processing and never land here), so we purge these unconditionally —
+        // even when hasNetworkErrors below skips the broad obsolete cleanup.
+        if (crawlResult.notFoundUrls && crawlResult.notFoundUrls.size > 0) {
+            logger.info(`Removing ${crawlResult.notFoundUrls.size} not-found (404) URLs`);
             for (const url of crawlResult.notFoundUrls) {
+                // Postgres markdown store
+                if (useMarkdownStore) {
+                    try {
+                        await this.markdownStore!.deleteMarkdown(url);
+                    } catch (pgError) {
+                        logger.error(`Failed to delete markdown from Postgres for ${url}:`, pgError);
+                    }
+                }
+                // Vector DB chunks
                 try {
-                    await this.markdownStore!.deleteMarkdown(url);
-                } catch (pgError) {
-                    logger.error(`Failed to delete markdown from Postgres for ${url}:`, pgError);
+                    if (dbConnection.type === 'sqlite') {
+                        DatabaseManager.removeChunksByUrlSQLite(dbConnection.db, url, logger);
+                    } else if (dbConnection.type === 'qdrant') {
+                        await DatabaseManager.removeChunksByUrlQdrant(dbConnection, url, logger);
+                    }
+                } catch (dbError) {
+                    logger.error(`Failed to delete chunks for 404 URL ${url}:`, dbError);
                 }
             }
         }
-        
+
         if (crawlResult.hasNetworkErrors) {
             logger.warn('Skipping cleanup due to network errors encountered during crawling. This prevents removal of valid chunks when the site is temporarily unreachable.');
         } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "doc2vec",
-    "version": "2.10.3",
+    "version": "2.10.4",
     "type": "commonjs",
     "description": "",
     "main": "dist/doc2vec.js",

--- a/tests/content-processor.test.ts
+++ b/tests/content-processor.test.ts
@@ -1247,6 +1247,31 @@ describe('ContentProcessor', () => {
             expect(processContent).not.toHaveBeenCalled();
         });
 
+        it('should remove a 404 URL from visitedUrls and record it in notFoundUrls', async () => {
+            const axiosModule = await import('axios');
+            vi.spyOn(axiosModule.default, 'head').mockRejectedValue(
+                Object.assign(new Error('Request failed with status code 404'), {
+                    response: { status: 404 },
+                })
+            );
+
+            const etagStore = {
+                get: vi.fn(),
+                set: vi.fn().mockResolvedValue(undefined),
+            };
+
+            const visited = new Set<string>();
+            const processContent = vi.fn().mockResolvedValue(true);
+            const result = await processor.crawlWebsite('https://example.com', websiteConfig, processContent, testLogger, visited, { etagStore });
+
+            // The dead URL must be recorded as not-found...
+            expect([...result.notFoundUrls].some(u => u.startsWith('https://example.com'))).toBe(true);
+            // ...and must NOT linger in visitedUrls. It was optimistically added
+            // when dequeued; leaving it there would make the obsolete-chunk
+            // cleanup treat the deleted page as still-live and never purge it.
+            expect(visited.size).toBe(0);
+        });
+
         it('should skip URL when HEAD returns 403', async () => {
             const axiosModule = await import('axios');
             vi.spyOn(axiosModule.default, 'head').mockRejectedValue(

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -759,6 +759,51 @@ describe('DatabaseManager', () => {
             expect(deleteCall[1].points).not.toContain('p2');
         });
 
+        it('should paginate through all scroll pages when finding obsolete chunks', async () => {
+            // Qdrant caps a single scroll at its page limit and returns a
+            // next_page_offset to fetch the rest. removeObsoleteChunksQdrant
+            // must follow that cursor — otherwise large collections would only
+            // have their first page examined and obsolete chunks beyond it
+            // (e.g. a deleted page in a 20k+ chunk collection) would survive.
+            const mockClient = {
+                scroll: vi.fn()
+                    .mockResolvedValueOnce({
+                        points: [
+                            { id: 'p1', payload: { url: 'https://example.com/old1', is_metadata: false } },
+                            { id: 'p2', payload: { url: 'https://example.com/current', is_metadata: false } },
+                        ],
+                        next_page_offset: 'cursor-2',
+                    })
+                    .mockResolvedValueOnce({
+                        points: [
+                            { id: 'p3', payload: { url: 'https://example.com/old2', is_metadata: false } },
+                        ],
+                        next_page_offset: null,
+                    }),
+                delete: vi.fn().mockResolvedValue({}),
+            };
+
+            const qdrantDb: QdrantDB = {
+                client: mockClient,
+                collectionName: 'test_col',
+                type: 'qdrant',
+            };
+
+            const visitedUrls = new Set(['https://example.com/current']);
+            await DatabaseManager.removeObsoleteChunksQdrant(qdrantDb, visitedUrls, 'https://example.com', testLogger);
+
+            // Both pages must be scrolled, second call carrying the cursor
+            expect(mockClient.scroll).toHaveBeenCalledTimes(2);
+            expect(mockClient.scroll.mock.calls[1][1].offset).toBe('cursor-2');
+
+            // Obsolete points from BOTH pages deleted; the visited one retained
+            expect(mockClient.delete).toHaveBeenCalledOnce();
+            const deleted = mockClient.delete.mock.calls[0][1].points;
+            expect(deleted).toContain('p1');
+            expect(deleted).toContain('p3');
+            expect(deleted).not.toContain('p2');
+        });
+
         it('should not delete metadata points from Qdrant', async () => {
             const mockClient = {
                 scroll: vi.fn().mockResolvedValue({

--- a/tests/doc2vec.test.ts
+++ b/tests/doc2vec.test.ts
@@ -74,6 +74,8 @@ vi.mock('../database', () => ({
         removeChunksByUrlQdrant: vi.fn().mockResolvedValue(undefined),
         getChunkHashesByUrlSQLite: vi.fn().mockReturnValue([]),
         getChunkHashesByUrlQdrant: vi.fn().mockResolvedValue([]),
+        getStoredUrlsByPrefixSQLite: vi.fn().mockReturnValue([]),
+        getStoredUrlsByPrefixQdrant: vi.fn().mockResolvedValue([]),
     },
 }));
 
@@ -741,6 +743,67 @@ sources:
             const configPath = writeTestConfig('run-routing.yaml', config);
             return new Doc2Vec(configPath);
         }
+
+        // ─── 404 cleanup during processWebsite ───────────────────────────
+        // A page that 404s during the crawl must have its chunks purged from
+        // the vector DB — not just the markdown store. Because a 404 is a
+        // definitive "gone" signal (network errors fall through to full
+        // processing and never reach notFoundUrls), the purge must run even
+        // when network errors cause the broad obsolete sweep to be skipped.
+        describe('404 cleanup', () => {
+            function makeLogger(): any {
+                const l: any = {
+                    info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+                    debug: vi.fn(), section: vi.fn(),
+                };
+                l.child = vi.fn(() => makeLogger());
+                return l;
+            }
+
+            const websiteConfig = {
+                type: 'website',
+                product_name: 'TestSite',
+                version: '1.0',
+                max_size: 50000,
+                url: 'https://example.com',
+                database_config: { type: 'sqlite', params: { db_path: ':memory:' } },
+            };
+
+            it('should delete chunks for 404 URLs from the vector DB during cleanup', async () => {
+                const { DatabaseManager } = await import('../database');
+                instance = createInstanceWithSources([websiteConfig]);
+                (instance as any).contentProcessor.crawlWebsite = vi.fn().mockResolvedValue({
+                    hasNetworkErrors: false,
+                    brokenLinks: [],
+                    notFoundUrls: new Set(['https://example.com/gone']),
+                });
+
+                await (instance as any).processWebsite(websiteConfig, makeLogger());
+
+                expect(DatabaseManager.removeChunksByUrlSQLite).toHaveBeenCalledWith(
+                    expect.anything(), 'https://example.com/gone', expect.anything(),
+                );
+            });
+
+            it('should purge 404 URLs even when network errors skip the broad cleanup', async () => {
+                const { DatabaseManager } = await import('../database');
+                instance = createInstanceWithSources([websiteConfig]);
+                (instance as any).contentProcessor.crawlWebsite = vi.fn().mockResolvedValue({
+                    hasNetworkErrors: true,
+                    brokenLinks: [],
+                    notFoundUrls: new Set(['https://example.com/gone']),
+                });
+
+                await (instance as any).processWebsite(websiteConfig, makeLogger());
+
+                // 404 chunks are still purged (definitive signal)...
+                expect(DatabaseManager.removeChunksByUrlSQLite).toHaveBeenCalledWith(
+                    expect.anything(), 'https://example.com/gone', expect.anything(),
+                );
+                // ...but the broad obsolete sweep is skipped when the site was flaky
+                expect(DatabaseManager.removeObsoleteChunksSQLite).not.toHaveBeenCalled();
+            });
+        });
 
         it('should route website source to processWebsite', async () => {
             instance = createInstanceWithSources([{


### PR DESCRIPTION
## Problem

Deleted docs pages that now return a hard **404** were never removed from Qdrant, even though doc2vec syncs succeed and are supposed to prune orphans. Confirmed with a live example: `https://agentgateway.dev/docs/standalone/main/integrations/llm-observability/helicone/` returns 404 but its chunks are still in the `agentgateway-dev_docs_standalone_main` collection.

Three compounding bugs were behind this.

### 1. Qdrant orphan cleanup wasn't paginated
`removeObsoleteChunksQdrant` scrolled with a single `limit: 10000` call and no `next_page_offset` follow-up. For any collection larger than the page limit — e.g. `kubernetes-io_docs` at **23,574 chunks** — only an arbitrary first page was ever examined, so ~57% of chunks were never evaluated for deletion. Now paginates through all pages.

### 2. 404 URLs were protected from cleanup
A crawled URL is added to `visitedUrls` at dequeue time, *before* the fetch. On a 404 it was never removed, so the obsolete-chunk cleanup (which deletes chunks whose URL isn't in `visitedUrls`) treated the dead page as still-live and kept its chunks indefinitely. Because previously-stored URLs are re-seeded into the crawl queue every run, this was self-perpetuating. Both the HEAD-path and GET-path 404 branches now remove the URL from `visitedUrls` (and the GET path now also records it in `notFoundUrls`).

### 3. `notFoundUrls` never purged the vector DB
The set of 404 URLs was only used to delete from the Postgres markdown store, never from Qdrant/SQLite. Cleanup now purges 404 URLs' chunks from the vector DB as well. This runs **before** the `hasNetworkErrors` guard, since a 404 is a definitive "gone" signal (network errors fall through to full processing and never reach `notFoundUrls`).

## Changes
- `database.ts` — paginate `removeObsoleteChunksQdrant` via `next_page_offset`
- `content-processor.ts` — delete 404 URLs from `visitedUrls` (HEAD + GET paths); record GET-path 404s in `notFoundUrls`
- `doc2vec.ts` — purge `notFoundUrls` chunks from the vector DB, ahead of the network-error guard
- `package.json` — bump to 2.10.4

## Tests
- Pagination across multiple scroll pages (`tests/database.test.ts`)
- 404 URL removed from `visitedUrls` + recorded in `notFoundUrls` (`tests/content-processor.test.ts`)
- Vector-DB purge of 404 URLs, including the network-error case (`tests/doc2vec.test.ts`)

Full suite: **556 passed**, 2 skipped.

## Note
This fixes orphan removal going forward — deleted pages are purged on the next sync that re-crawls them. It does **not** retroactively clean already-stale data (e.g. the existing Helicone chunks); a one-off cleanup can be run separately if immediate removal is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)