### PR TITLE
mcp: run image as numeric non-root user

### DIFF
--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -86,8 +86,8 @@ COPY --from=builder /app/build /app/build
 COPY --from=builder /app/node_modules /app/node_modules
 
 # Create non-root user and verify build directory
-RUN addgroup -g 1001 -S nodejs     && \
-    adduser -S kagent -u 1001 -G nodejs
+RUN addgroup -g 14000 -S doc2vec   && \
+    adduser -S doc2vec -u 14000 -G doc2vec
 
 ADD https://doc-sqlite-db.s3.sa-east-1.amazonaws.com/kubernetes.db /app/build/kubernetes.db
 ADD https://doc-sqlite-db.s3.sa-east-1.amazonaws.com/istio.db /app/build/istio.db
@@ -107,12 +107,15 @@ ADD https://doc-sqlite-db.s3.sa-east-1.amazonaws.com/ambient.db /app/build/ambie
 RUN for file in /app/build/*.db; do echo "Checksum for $file:";sha256sum "$file";done
 
 # Ensure the app directory is owned by the non-root user
-RUN chown -R kagent:nodejs /app
+RUN chown -R doc2vec:doc2vec /app
 
 LABEL org.opencontainers.image.source=https://github.com/kagent-dev/doc2vec
 LABEL org.opencontainers.image.description="Kagent Doc2Vec MCP"
 LABEL org.opencontainers.image.authors="Kagent Creators 🤖"
 
 EXPOSE 3001
+
+# Run as the numeric non-root UID so kubelet can enforce runAsNonRoot
+USER 14000
 
 ENTRYPOINT ["node", "build/index.js"]


### PR DESCRIPTION
## What

`mcp/Dockerfile` creates a non-root user but never sets `USER`, so the container runs as root. This sets `USER` to the numeric UID `14000` and aligns the runtime user with the root image's `doc2vec:14000` account.

## Why

With no `USER`, the image runs as root, which forces consumers to pin `runAsUser` in their pod spec and blocks rootless or OpenShift-style deployments. A numeric `USER` lets kubelet verify `runAsNonRoot` at admission time (a non-numeric username cannot be checked). It also lets downstream charts, such as kagent's `querydoc` subchart that pulls this image, drop their `runAsUser` pin.

## How verified

Built with buildx and ran the image:
- `docker run --entrypoint id` reports `uid=14000(doc2vec) gid=14000(doc2vec)`
- `docker inspect -f '{{.Config.User}}'` reports `14000`
- `/app` and `/app/build` are owned by `doc2vec`, and the runtime user can write to `/app/build` (needed for SQLite journal/WAL files)
- the entrypoint starts as UID 14000 with no permission errors
