### PR TITLE
fix(github): re-sync closed/updated issues and purge stale chunks

### DIFF
--- a/doc2vec.ts
+++ b/doc2vec.ts
@@ -297,14 +297,13 @@ export class Doc2Vec {
             let issues: any[] = [];
             let page = 1;
             const perPage = 100;
-            const sinceTimestamp = new Date(sinceDate);
 
             while (true) {
                 // Log progress every 10 pages to reduce noise
                 if (page === 1 || page % 10 === 0) {
                     logger.debug(`Fetching issues page ${page}... (${issues.length} issues so far)`);
                 }
-                
+
                 const data = await fetchWithRetry(GITHUB_API_URL, {
                     per_page: perPage,
                     page,
@@ -314,10 +313,15 @@ export class Doc2Vec {
 
                 if (data.length === 0) break;
 
-                const filtered = data.filter((issue: any) => new Date(issue.created_at) >= sinceTimestamp);
-                issues = issues.concat(filtered);
+                // The `since` param already scopes results to issues whose
+                // updated_at is after sinceDate — i.e. anything created, closed,
+                // reopened, edited, or newly commented since the last run. Do NOT
+                // re-filter by created_at: an old issue that was just closed or
+                // received a new comment has an old created_at and would be
+                // dropped, leaving its status and comments permanently stale.
+                issues = issues.concat(data);
 
-                if (filtered.length < data.length) break;
+                if (data.length < perPage) break;
                 page++;
             }
             return issues;
@@ -368,7 +372,19 @@ export class Doc2Vec {
             
             const chunks = await this.contentProcessor.chunkMarkdown(markdown, issueConfig, url);
             logger.info(`Issue #${issueNumber}: Created ${chunks.length} chunks`);
-            
+
+            // Purge the issue's existing chunks before inserting the fresh set.
+            // chunk_id is a content hash, so when an issue changes (closed/reopened,
+            // edited, new comments) the regenerated chunks get new ids and the old
+            // ones would otherwise linger — leaving stale state ("open") and missing
+            // the latest comments in search results. All chunks for an issue share
+            // its unique url, so delete-by-url reconciles them exactly.
+            if (dbConnection.type === 'sqlite') {
+                DatabaseManager.removeChunksByUrlSQLite(dbConnection.db, url, logger);
+            } else if (dbConnection.type === 'qdrant') {
+                await DatabaseManager.removeChunksByUrlQdrant(dbConnection, url, logger);
+            }
+
             // Process and store each chunk immediately
             for (const chunk of chunks) {
                 const chunkHash = Utils.generateHash(chunk.content);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "doc2vec",
-    "version": "2.10.5",
+    "version": "2.10.6",
     "type": "commonjs",
     "description": "",
     "main": "dist/doc2vec.js",

--- a/tests/doc2vec.test.ts
+++ b/tests/doc2vec.test.ts
@@ -162,6 +162,7 @@ import { Doc2Vec } from '../doc2vec';
 import { DatabaseManager } from '../database';
 import { ContentProcessor } from '../content-processor';
 import { Logger } from '../logger';
+import axios from 'axios';
 
 // ─── Test helpers ────────────────────────────────────────────────────────────
 
@@ -1894,6 +1895,86 @@ sources:
 
             // good.md should still be processed despite bad.md failing
             expect(processChunksSpy).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // GitHub issues: incremental re-processing of updated / closed issues
+    // ─────────────────────────────────────────────────────────────────────────
+    describe('fetchAndProcessGitHubIssues', () => {
+        const repo = 'octo/repo';
+        const issuesUrl = `https://api.github.com/repos/${repo}/issues`;
+        const issueUrl = (n: number) => `https://github.com/${repo}/issues/${n}`;
+
+        function makeInstance() {
+            const configPath = writeTestConfig('gh-issues.yaml', makeMinimalConfig());
+            return new Doc2Vec(configPath) as any;
+        }
+
+        // getLastRunDate is mocked (line ~62) to return 2025-01-01T00:00:00Z.
+        // An issue created BEFORE that date but closed/commented AFTER it is the
+        // exact case that regressed: GitHub's `since` returns it, but the old
+        // created_at filter used to drop it.
+        const oldButRecentlyClosedIssue = {
+            number: 42,
+            title: 'Old bug that just got closed',
+            user: { login: 'alice' },
+            state: 'closed',
+            created_at: '2024-06-01T00:00:00Z', // before last run
+            updated_at: '2025-02-01T00:00:00Z', // closed/commented after last run
+            labels: [],
+            body: 'A long-standing bug.',
+        };
+
+        function mockGitHubApi(issues: any[], comments: any[] = []) {
+            (axios.get as any).mockImplementation((url: string, opts?: any) => {
+                if (url.endsWith('/comments')) {
+                    return Promise.resolve({ data: comments });
+                }
+                // Issues list: only page 1 carries data. Any page beyond the first
+                // returns empty so pagination terminates deterministically.
+                const page = opts?.params?.page ?? 1;
+                return Promise.resolve({ data: page === 1 ? issues : [] });
+            });
+        }
+
+        it('processes an old issue closed since the last run (no created_at filtering)', async () => {
+            const instance = makeInstance();
+            mockGitHubApi([oldButRecentlyClosedIssue]);
+
+            await instance.fetchAndProcessGitHubIssues(
+                repo,
+                { product_name: repo },
+                { type: 'sqlite', db: {} },
+                instance.logger,
+            );
+
+            // The issue must be processed, not silently dropped for being old.
+            const chunkCalls = instance.contentProcessor.chunkMarkdown.mock.calls;
+            expect(chunkCalls.length).toBe(1);
+            // Markdown reflects the up-to-date (closed) state.
+            expect(chunkCalls[0][0]).toContain('**State:** closed');
+            expect(chunkCalls[0][2]).toBe(issueUrl(42));
+        });
+
+        it('purges the issue\'s existing chunks before storing the refreshed set', async () => {
+            const instance = makeInstance();
+            mockGitHubApi([oldButRecentlyClosedIssue]);
+
+            await instance.fetchAndProcessGitHubIssues(
+                repo,
+                { product_name: repo },
+                { type: 'sqlite', db: {} },
+                instance.logger,
+            );
+
+            // Stale chunks (content-hash ids) would otherwise linger with the old
+            // "open" state and missing comments.
+            expect(DatabaseManager.removeChunksByUrlSQLite).toHaveBeenCalledWith(
+                {},
+                issueUrl(42),
+                expect.anything(),
+            );
         });
     });
 });


### PR DESCRIPTION
## Problem

When a GitHub issue was **closed** (or reopened/edited) or received **new comments**, those changes never reached the index. Two independent bugs in the issue-sync path caused this:

### Bug 1 — updated old issues were filtered out
`fetchAllIssues` correctly asked the API for `state:'all'` + `since:lastRunDate` (which returns any issue whose `updated_at` changed — closed, reopened, edited, newly commented), but then re-filtered the results by `created_at >= sinceDate` and broke pagination early. An issue **created before the last run but closed/commented since** has an old `created_at`, so it was silently dropped — leaving its status and comments permanently stale.

**Fix:** removed the `created_at` filter; pagination runs until a short page is returned.

### Bug 2 — stale chunks were never purged
`chunk_id` is a hash of chunk *content*, so a changed issue regenerates chunks with new ids. `processIssue` only inserted them and never removed the issue's previous chunks, so the old `"open"`-state chunk lingered alongside the new one. Every other re-processing path (web-crawl, code) already calls `removeChunksByUrl*` first — the issue path didn't.

**Fix:** delete the issue's chunks by URL (SQLite + Qdrant) before storing the refreshed set.

## Tests
Added coverage for both: an old-but-recently-closed issue is now processed with up-to-date state, and its stale chunks are purged first. Full `doc2vec` suite: 88/88 pass; typecheck clean.

## ⚠️ One-time backfill required after deploy
Issues that changed *while the buggy code ran* won't self-heal, because `lastRunDate` has advanced past them. To repair them once: clear the stored `last_run_<owner>_<repo>` key (SQLite `vec_metadata`, or the Qdrant metadata point) so the `since` window reopens to `start_date`, then run a sync. Normal incremental syncs self-correct from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)