### PR TITLE
feat(controller): controller mode with scheduler, Postgres persistence, and web UI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # Dependencies & build output (reinstalled/regenerated inside the image)
 node_modules
+ui/node_modules
 dist
 build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN npm ci --ignore-scripts
 
 COPY --chown=doc2vec:doc2vec . .
 
-RUN npm run build
+RUN npm run build && npm run build:ui
 
 FROM base AS prod-deps
 
@@ -68,5 +68,8 @@ COPY --from=prod-deps --chown=doc2vec:doc2vec /app/package*.json ./
 COPY --from=prod-deps --chown=doc2vec:doc2vec /app/node_modules ./node_modules
 COPY --from=builder --chown=doc2vec:doc2vec /app/dist ./dist
 COPY --from=builder --chown=doc2vec:doc2vec /app/README.md /app/LICENSE /app/config.yaml ./
+
+# Controller mode serves its API/UI here (one-shot sync runs ignore it)
+EXPOSE 8080
 
 USER doc2vec

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,11 @@ FROM node:20-slim AS base
 
 WORKDIR /app
 
-ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
-
+# NOTE: chromium from apt is kept as the shared-library provider and the
+# linux/arm64 fallback, but it is no longer the browser we run on amd64 —
+# Debian has shipped chromium builds that crash at startup in containers
+# (150.0.7871 dies with SIGTRAP immediately). The runtime stage downloads
+# Puppeteer's version-matched Chrome for Testing instead.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     sqlite3 \
@@ -73,3 +76,10 @@ COPY --from=builder --chown=doc2vec:doc2vec /app/README.md /app/LICENSE /app/con
 EXPOSE 8080
 
 USER doc2vec
+
+# Version-matched Chrome for Testing (see note in the base stage). Published
+# for linux/amd64 only — arm64 falls back to the apt chromium at runtime.
+ENV PUPPETEER_CACHE_DIR=/home/doc2vec/.cache/puppeteer
+RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
+      npx puppeteer browsers install chrome; \
+    fi

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The primary goal is to prepare documentation content for Retrieval-Augmented Gen
 *   **Incremental Updates:** For GitHub and Zendesk sources, tracks the last run date to only fetch new or updated issues/tickets.
 *   **Cleanup:** Removes obsolete chunks from the database corresponding to pages or files that are no longer found during processing.
 *   **Configuration:** Driven by a YAML configuration file (`config.yaml`) specifying sites, repositories, local directories, Zendesk instances, database types, metadata, and other parameters.
+*   **[Controller Mode](#controller-mode):** Optionally runs as a long-lived controller that schedules sync jobs from multiple config files (cron `schedule` field), persists run history and statistics in Postgres, and serves a web UI with live log streaming — read-only (configs from files/ConfigMap) or read-write (create/edit configs from the UI).
 *   **Structured Logging:** Uses a custom logger (`logger.ts`) with levels, timestamps, colors, progress bars, and child loggers for clear execution monitoring.
 
 ## Chunk Metadata & Page Reconstruction
@@ -436,6 +437,96 @@ The script will then:
 6.  For all sources: Chunk content, check for changes, generate embeddings (if needed), and store/update in the database.
 7.  Cleanup obsolete chunks.
 8.  Output detailed logs.
+
+## Controller Mode
+
+Besides the one-shot sync, doc2vec can run as a **long-lived controller** that schedules sync jobs, records run history and statistics in Postgres, and serves a web UI for monitoring and managing configs:
+
+```bash
+doc2vec controller --database-url postgres://user:pass@host:5432/doc2vec ./configs/
+```
+
+Open http://localhost:8080 to see the dashboard: configs with their schedule and next run, run history with per-source statistics, and live log streaming for running jobs.
+
+### Scheduling
+
+Add a top-level cron `schedule` (and optionally a display `name`) to a config file, and the controller runs it automatically:
+
+```yaml
+name: product-docs
+schedule: "0 2 * * *"   # every day at 02:00
+sources:
+  - type: website
+    ...
+```
+
+Configs without a `schedule` are still listed in the UI and can be triggered manually with **Run now**. Each run executes `doc2vec run <config.yaml>` as a child process; overlapping runs of the same config are skipped, and `--max-parallel` (default 1) caps how many sync jobs run at once — keep it low, since website sources launch a headless Chromium.
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--database-url <url>` | `DATABASE_URL` env | Postgres connection string (required) |
+| `--port <n>` | `8080` (or `PORT`) | HTTP port for the API and UI |
+| `--read-write` | off (read-only) | Allow creating/editing/deleting configs from the UI |
+| `--config-dir <dir>` | — | Where UI-created configs are written (required with `--read-write`) |
+| `--max-parallel <n>` | `1` | Max concurrent sync jobs |
+| `--reload-interval <s>` | `30` | How often config files are re-read for changes |
+| `--log-retention-days <n>` | `14` | Run logs older than this are pruned (run history is kept) |
+
+Positional arguments are config files and/or directories (directories are scanned for `*.yaml`/`*.yml`, and re-scanned on every reload).
+
+### Read-only vs read-write
+
+- **Read-only** (default): configs come solely from the files passed on the command line — ideal for Kubernetes, where they live in a ConfigMap. The UI can view configs, trigger runs, and browse history/stats, but not modify anything. ConfigMap updates are picked up automatically via content-hash polling.
+- **Read-write** (`--read-write --config-dir ./configs`): the UI can also create, edit, and delete config YAML files. Files stay the source of truth on disk; concurrent edits are protected by a content-hash check.
+
+In both modes the UI always shows raw YAML: `${ENV_VAR}` secret placeholders are **never** resolved outside the sync job itself.
+
+### Kubernetes example
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: doc2vec-controller
+spec:
+  replicas: 1        # keep a single replica: the scheduler is not distributed
+  selector:
+    matchLabels: { app: doc2vec-controller }
+  template:
+    metadata:
+      labels: { app: doc2vec-controller }
+    spec:
+      containers:
+        - name: controller
+          image: ghcr.io/kagent-dev/doc2vec:latest
+          command: ["node", "dist/doc2vec.js", "controller", "/etc/doc2vec"]
+          ports:
+            - containerPort: 8080
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef: { name: doc2vec-secrets, key: database-url }
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef: { name: doc2vec-secrets, key: openai-api-key }
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/doc2vec
+          resources:
+            requests: { memory: 1Gi }
+            limits: { memory: 4Gi }   # website sources launch headless Chromium
+      volumes:
+        - name: configs
+          configMap: { name: doc2vec-configs }
+```
+
+The controller detects ConfigMap updates without a restart. Health endpoint: `GET /api/health`.
+
+### API
+
+The UI is backed by a small REST API you can also use directly: `GET /api/configs`, `POST /api/configs/:id/run`, `GET /api/runs?configId=`, `GET /api/runs/:id/logs`, `POST /api/runs/:id/cancel`, `GET /api/configs/:id/stats?days=30`, plus server-sent events at `GET /api/events` and `GET /api/runs/:id/logs/stream`.
 
 ## Database Options
 

--- a/README.md
+++ b/README.md
@@ -473,8 +473,15 @@ Configs without a `schedule` are still listed in the UI and can be triggered man
 | `--max-parallel <n>` | `1` | Max concurrent sync jobs |
 | `--reload-interval <s>` | `30` | How often config files are re-read for changes |
 | `--log-retention-days <n>` | `14` | Run logs older than this are pruned (run history is kept) |
+| `--slack-webhook-url <url>` | `SLACK_WEBHOOK_URL` env | Slack incoming webhook — post a message when a run finishes |
+| `--slack-notify <mode>` | `all` | `all` or `failures` (failures also covers canceled runs) |
+| `--public-url <url>` | `PUBLIC_URL` env | Externally reachable base URL, used for "view run" links in notifications |
 
 Positional arguments are config files and/or directories (directories are scanned for `*.yaml`/`*.yml`, and re-scanned on every reload).
+
+### Slack notifications
+
+With `--slack-webhook-url` (or `SLACK_WEBHOOK_URL`) set, the controller posts to a [Slack incoming webhook](https://api.slack.com/messaging/webhooks) whenever a run reaches a terminal state — ✅ succeeded, ❌ failed (naming the failing sources and their errors), or ⚠️ canceled. Overlap-`skipped` runs are not notified. Set `--slack-notify failures` to silence successes, and `--public-url https://doc2vec.example.com` to get clickable "view run" links.
 
 ### Read-only vs read-write
 

--- a/content-processor.ts
+++ b/content-processor.ts
@@ -34,6 +34,30 @@ export class BrowserLaunchError extends Error {
 }
 
 /**
+ * Resolve which browser binary to launch, in order of preference:
+ *  1. PUPPETEER_EXECUTABLE_PATH (explicit override)
+ *  2. Puppeteer's own downloaded Chrome for Testing (version-matched, the
+ *     reliable choice — Debian's chromium package has shipped builds that
+ *     crash at startup in containers, e.g. 150.0.7871 SIGTRAPs immediately)
+ *  3. A system chromium, as the fallback (also covers linux/arm64, where
+ *     Chrome for Testing is not published)
+ *  4. undefined — let puppeteer decide
+ */
+export function resolveBrowserExecutablePath(): string | undefined {
+    const override = process.env.PUPPETEER_EXECUTABLE_PATH;
+    if (override) return override;
+    try {
+        const bundled = puppeteer.executablePath();
+        if (bundled && fs.existsSync(bundled)) return bundled;
+    } catch {
+        // no browser downloaded for this platform
+    }
+    if (fs.existsSync('/usr/bin/chromium')) return '/usr/bin/chromium';
+    if (fs.existsSync('/usr/bin/chromium-browser')) return '/usr/bin/chromium-browser';
+    return undefined;
+}
+
+/**
  * Best-effort snapshot of process + container memory, for diagnosing browser
  * launch failures (the usual cause in Kubernetes is the pod's memory cgroup —
  * Chromium forks, then its renderers are immediately OOM-killed).
@@ -58,6 +82,24 @@ function memoryDiagnostics(): string {
         }
     } catch {
         // diagnostics only — never fail because of them
+    }
+    try {
+        // /proc/meminfo reflects the NODE in Kubernetes — catches host-level pressure
+        const meminfo = fs.readFileSync('/proc/meminfo', 'utf8');
+        const available = meminfo.match(/^MemAvailable:\s+(\d+) kB/m);
+        if (available) {
+            parts.push(`node available ${gib(Number(available[1]) * 1024)}`);
+        }
+    } catch {
+        // not Linux
+    }
+    try {
+        // Chromium writes its profile and (with --disable-dev-shm-usage) its
+        // shared memory under /tmp — a full disk breaks launches
+        const stat = fs.statfsSync('/tmp');
+        parts.push(`/tmp free ${gib(stat.bavail * stat.bsize)}`);
+    } catch {
+        // statfs unavailable
     }
     return parts.join(', ');
 }
@@ -415,14 +457,7 @@ export class ContentProcessor {
         let page: Page | null = null;
 
         const launchBrowser = async (): Promise<{ browser: Browser; page: Page }> => {
-            let executablePath: string | undefined = process.env.PUPPETEER_EXECUTABLE_PATH;
-            if (!executablePath) {
-                if (fs.existsSync('/usr/bin/chromium')) {
-                    executablePath = '/usr/bin/chromium';
-                } else if (fs.existsSync('/usr/bin/chromium-browser')) {
-                    executablePath = '/usr/bin/chromium-browser';
-                }
-            }
+            const executablePath = resolveBrowserExecutablePath();
             const launchOptions = {
                 executablePath,
                 args: [
@@ -974,17 +1009,8 @@ export class ContentProcessor {
                 page = existingPage;
             } else {
                 // Standalone mode: launch a browser for this single page
-                let executablePath: string | undefined = process.env.PUPPETEER_EXECUTABLE_PATH;
-                if (!executablePath) {
-                    if (fs.existsSync('/usr/bin/chromium')) {
-                        executablePath = '/usr/bin/chromium';
-                    } else if (fs.existsSync('/usr/bin/chromium-browser')) {
-                        executablePath = '/usr/bin/chromium-browser';
-                    }
-                }
-                
                 browser = await puppeteer.launch({
-                    executablePath,
+                    executablePath: resolveBrowserExecutablePath(),
                     args: [
                         '--no-sandbox',
                         '--disable-setuid-sandbox',

--- a/content-processor.ts
+++ b/content-processor.ts
@@ -33,6 +33,35 @@ export class BrowserLaunchError extends Error {
     }
 }
 
+/**
+ * Best-effort snapshot of process + container memory, for diagnosing browser
+ * launch failures (the usual cause in Kubernetes is the pod's memory cgroup —
+ * Chromium forks, then its renderers are immediately OOM-killed).
+ */
+function memoryDiagnostics(): string {
+    const gib = (bytes: number) => `${(bytes / 1024 ** 3).toFixed(2)}GiB`;
+    const parts: string[] = [`node rss ${gib(process.memoryUsage().rss)}`];
+    try {
+        // cgroup v2, else v1 — absent entirely outside Linux/containers
+        let current: string | undefined;
+        let max: string | undefined;
+        if (fs.existsSync('/sys/fs/cgroup/memory.current')) {
+            current = fs.readFileSync('/sys/fs/cgroup/memory.current', 'utf8').trim();
+            max = fs.readFileSync('/sys/fs/cgroup/memory.max', 'utf8').trim();
+        } else if (fs.existsSync('/sys/fs/cgroup/memory/memory.usage_in_bytes')) {
+            current = fs.readFileSync('/sys/fs/cgroup/memory/memory.usage_in_bytes', 'utf8').trim();
+            max = fs.readFileSync('/sys/fs/cgroup/memory/memory.limit_in_bytes', 'utf8').trim();
+        }
+        if (current !== undefined && max !== undefined) {
+            const unlimited = max === 'max' || Number(max) > 2 ** 60;
+            parts.push(`cgroup ${gib(Number(current))} used / ${unlimited ? 'no limit' : gib(Number(max))}`);
+        }
+    } catch {
+        // diagnostics only — never fail because of them
+    }
+    return parts.join(', ');
+}
+
 export class ContentProcessor {
     private turndownService: TurndownService;
     private logger: Logger;
@@ -413,13 +442,13 @@ export class ContentProcessor {
                 // memory pressure from a page that just closed). If the browser
                 // cannot launch at all, no page in this crawl can be processed,
                 // so escalate as fatal instead of failing every URL one by one.
-                logger.warn('Browser launch failed, retrying once in 5s...', firstError);
+                logger.warn(`Browser launch failed (${memoryDiagnostics()}), retrying once in 5s...`, firstError);
                 await new Promise(resolve => setTimeout(resolve, 5000));
                 try {
                     b = await puppeteer.launch(launchOptions);
                 } catch (secondError) {
                     throw new BrowserLaunchError(
-                        `browser failed to launch twice: ${secondError instanceof Error ? secondError.message : String(secondError)}`
+                        `browser failed to launch twice (${memoryDiagnostics()}): ${secondError instanceof Error ? secondError.message : String(secondError)}`
                     );
                 }
             }

--- a/content-processor.ts
+++ b/content-processor.ts
@@ -20,6 +20,19 @@ import {
 import type { TokenChunker, Tokenizer } from '@chonkiejs/core';
 import { CodeChunker } from './code-chunker';
 
+/**
+ * Thrown when the browser cannot be launched at all (even after a retry).
+ * Without a browser no page in the crawl can be processed, so this aborts the
+ * whole website source — the run is then reported as failed instead of
+ * "succeeding" with an error on every URL.
+ */
+export class BrowserLaunchError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'BrowserLaunchError';
+    }
+}
+
 export class ContentProcessor {
     private turndownService: TurndownService;
     private logger: Logger;
@@ -381,7 +394,7 @@ export class ContentProcessor {
                     executablePath = '/usr/bin/chromium-browser';
                 }
             }
-            const b = await puppeteer.launch({
+            const launchOptions = {
                 executablePath,
                 args: [
                     '--no-sandbox',
@@ -391,7 +404,25 @@ export class ContentProcessor {
                     '--disable-extensions',
                 ],
                 protocolTimeout: 60000,
-            });
+            };
+            let b: Browser;
+            try {
+                b = await puppeteer.launch(launchOptions);
+            } catch (firstError) {
+                // One retry after a pause — the failure may be transient (e.g.
+                // memory pressure from a page that just closed). If the browser
+                // cannot launch at all, no page in this crawl can be processed,
+                // so escalate as fatal instead of failing every URL one by one.
+                logger.warn('Browser launch failed, retrying once in 5s...', firstError);
+                await new Promise(resolve => setTimeout(resolve, 5000));
+                try {
+                    b = await puppeteer.launch(launchOptions);
+                } catch (secondError) {
+                    throw new BrowserLaunchError(
+                        `browser failed to launch twice: ${secondError instanceof Error ? secondError.message : String(secondError)}`
+                    );
+                }
+            }
             const p = await b.newPage();
             return { browser: b, page: p };
         };
@@ -719,6 +750,14 @@ export class ContentProcessor {
                         }
                     }
                 } catch (error: any) {
+                    // A browser that cannot launch is fatal for the whole crawl —
+                    // rethrow so the source (and the run) is reported as failed
+                    // rather than logging an error per URL and finishing "green".
+                    if (error instanceof BrowserLaunchError) {
+                        logger.error(`Aborting crawl of ${baseUrl}: ${error.message}`);
+                        throw error;
+                    }
+
                     const status = this.getHttpStatus(error);
 
                     // ── Handle 429 (Too Many Requests) with retry ──

--- a/controller/config-registry.ts
+++ b/controller/config-registry.ts
@@ -1,0 +1,261 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'js-yaml';
+import { Cron } from 'croner';
+import { Logger } from '../logger';
+import { ControllerEvents } from './events';
+import { ControllerStore } from './store';
+import { ConfigRecord, ConflictError, NotFoundError, SourceSummary, ValidationError } from './types';
+
+export interface ParsedConfigMeta {
+    name: string;
+    schedule: string | null;
+    sourceSummary: SourceSummary[];
+    parseError: string | null;
+}
+
+/**
+ * Parse raw config YAML WITHOUT ${ENV} substitution (secrets stay as placeholders)
+ * and without Doc2Vec.loadConfig()'s process.exit() behavior — invalid files are
+ * reported, never fatal.
+ */
+export function parseConfigMeta(content: string, filePath: string): ParsedConfigMeta {
+    const fallbackName = path.basename(filePath).replace(/\.ya?ml$/i, '');
+    try {
+        const parsed = yaml.load(content) as any;
+        if (!parsed || typeof parsed !== 'object') {
+            return { name: fallbackName, schedule: null, sourceSummary: [], parseError: 'config is empty or not a YAML mapping' };
+        }
+        if (!Array.isArray(parsed.sources) || parsed.sources.length === 0) {
+            return { name: parsed.name || fallbackName, schedule: null, sourceSummary: [], parseError: 'config has no sources' };
+        }
+        const sourceSummary: SourceSummary[] = parsed.sources.map((s: any) => ({
+            type: String(s?.type ?? 'unknown'),
+            product_name: String(s?.product_name ?? 'unknown'),
+            ...(s?.version !== undefined && { version: String(s.version) }),
+        }));
+        let schedule: string | null = null;
+        let parseError: string | null = null;
+        if (parsed.schedule !== undefined && parsed.schedule !== null) {
+            schedule = String(parsed.schedule);
+            if (!isValidCron(schedule)) {
+                parseError = `invalid cron expression: ${schedule}`;
+                schedule = null;
+            }
+        }
+        return { name: String(parsed.name || fallbackName), schedule, sourceSummary, parseError };
+    } catch (err) {
+        return {
+            name: fallbackName,
+            schedule: null,
+            sourceSummary: [],
+            parseError: err instanceof Error ? err.message : String(err),
+        };
+    }
+}
+
+export function isValidCron(expr: string): boolean {
+    try {
+        new Cron(expr, { paused: true }).stop();
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+export function hashContent(content: string): string {
+    return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+export interface ConfigRegistryOptions {
+    configArgs: string[];
+    configDir?: string;
+    readWrite: boolean;
+    reloadIntervalSec: number;
+}
+
+/**
+ * Watches the config files/directories passed on the CLI (plus --config-dir in
+ * read-write mode), keeps the d2v_configs table in sync, and — in read-write mode —
+ * persists UI edits back to YAML files on disk. Disk is the source of truth.
+ *
+ * Change detection is content-hash polling rather than fs.watch: Kubernetes
+ * ConfigMap updates arrive as atomic symlink swaps that fs.watch misses.
+ */
+export class ConfigRegistry {
+    private byPath = new Map<string, ConfigRecord>();
+    private timer: ReturnType<typeof setInterval> | null = null;
+    private syncing = false;
+
+    constructor(
+        private opts: ConfigRegistryOptions,
+        private store: ControllerStore,
+        private events: ControllerEvents,
+        private logger: Logger
+    ) {}
+
+    async start(): Promise<void> {
+        await this.sync();
+        this.timer = setInterval(() => {
+            this.sync().catch(err => this.logger.error('Config re-sync failed:', err));
+        }, Math.max(this.opts.reloadIntervalSec, 5) * 1000);
+        this.timer.unref();
+    }
+
+    stop(): void {
+        if (this.timer) clearInterval(this.timer);
+        this.timer = null;
+    }
+
+    list(): ConfigRecord[] {
+        return [...this.byPath.values()].sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    get(id: number): ConfigRecord | undefined {
+        return [...this.byPath.values()].find(c => c.id === id);
+    }
+
+    /** Expand CLI args (files and directories) into the current set of config files. */
+    private discoverFiles(): string[] {
+        const files = new Set<string>();
+        const addDir = (dir: string) => {
+            for (const entry of fs.readdirSync(dir)) {
+                if (/\.ya?ml$/i.test(entry) && !entry.startsWith('.')) {
+                    const full = path.join(dir, entry);
+                    if (fs.statSync(full).isFile()) files.add(full);
+                }
+            }
+        };
+        for (const arg of this.opts.configArgs) {
+            const abs = path.resolve(arg);
+            if (!fs.existsSync(abs)) {
+                this.logger.warn(`Config path does not exist: ${abs}`);
+                continue;
+            }
+            if (fs.statSync(abs).isDirectory()) {
+                addDir(abs);
+            } else {
+                files.add(abs);
+            }
+        }
+        if (this.opts.readWrite && this.opts.configDir && fs.existsSync(this.opts.configDir)) {
+            addDir(path.resolve(this.opts.configDir));
+        }
+        return [...files];
+    }
+
+    async sync(): Promise<void> {
+        if (this.syncing) return;
+        this.syncing = true;
+        try {
+            const files = this.discoverFiles();
+            const seen = new Set<string>();
+            let changed = false;
+
+            for (const file of files) {
+                seen.add(file);
+                let content: string;
+                try {
+                    content = fs.readFileSync(file, 'utf8');
+                } catch (err) {
+                    this.logger.warn(`Failed to read config ${file}:`, err);
+                    continue;
+                }
+                const contentHash = hashContent(content);
+                const existing = this.byPath.get(file);
+                if (existing && existing.content_hash === contentHash) continue;
+
+                const meta = parseConfigMeta(content, file);
+                if (meta.parseError) {
+                    this.logger.warn(`Config ${file} has a problem: ${meta.parseError}`);
+                }
+                const record = await this.store.upsertConfig({
+                    path: file,
+                    name: meta.name,
+                    content,
+                    contentHash,
+                    schedule: meta.schedule,
+                    sourceSummary: meta.sourceSummary,
+                    parseError: meta.parseError,
+                });
+                this.byPath.set(file, record);
+                changed = true;
+                this.logger.info(`${existing ? 'Reloaded' : 'Loaded'} config '${record.name}' from ${file}` +
+                    (record.schedule ? ` (schedule: ${record.schedule})` : ' (manual runs only)'));
+            }
+
+            for (const [file] of this.byPath) {
+                if (!seen.has(file)) {
+                    this.logger.info(`Config file removed: ${file}`);
+                    await this.store.markConfigDeleted(file);
+                    this.byPath.delete(file);
+                    changed = true;
+                }
+            }
+
+            if (changed) this.events.emitConfigUpdate();
+        } finally {
+            this.syncing = false;
+        }
+    }
+
+    // ------------------------------------------------------------- read-write mode
+
+    /** Validate content for create/update: must parse and declare sources; cron must be valid. */
+    private validateForWrite(content: string, filePath: string): ParsedConfigMeta {
+        const meta = parseConfigMeta(content, filePath);
+        if (meta.parseError) {
+            throw new ValidationError(meta.parseError);
+        }
+        return meta;
+    }
+
+    private atomicWrite(target: string, content: string): void {
+        const tmp = `${target}.tmp-${process.pid}`;
+        fs.writeFileSync(tmp, content, 'utf8');
+        fs.renameSync(tmp, target);
+    }
+
+    async create(filename: string, content: string): Promise<ConfigRecord> {
+        if (!this.opts.configDir) {
+            throw new ValidationError('no --config-dir configured');
+        }
+        if (!/^[A-Za-z0-9][A-Za-z0-9._-]*\.ya?ml$/.test(filename)) {
+            throw new ValidationError('filename must be a plain name ending in .yaml or .yml');
+        }
+        const target = path.join(path.resolve(this.opts.configDir), filename);
+        if (fs.existsSync(target)) {
+            throw new ConflictError(`config file ${filename} already exists`);
+        }
+        this.validateForWrite(content, target);
+        this.atomicWrite(target, content);
+        await this.sync();
+        const record = this.byPath.get(target);
+        if (!record) throw new Error('config was written but failed to load');
+        return record;
+    }
+
+    async update(id: number, content: string, baseHash: string): Promise<ConfigRecord> {
+        const existing = this.get(id);
+        if (!existing) throw new NotFoundError(`config ${id} not found`);
+        if (existing.content_hash !== baseHash) {
+            throw new ConflictError('config changed on disk since you loaded it — reload and reapply your edits');
+        }
+        this.validateForWrite(content, existing.path);
+        this.atomicWrite(existing.path, content);
+        await this.sync();
+        const record = this.byPath.get(existing.path);
+        if (!record) throw new Error('config was written but failed to load');
+        return record;
+    }
+
+    async delete(id: number): Promise<void> {
+        const existing = this.get(id);
+        if (!existing) throw new NotFoundError(`config ${id} not found`);
+        fs.unlinkSync(existing.path);
+        await this.store.markConfigDeleted(existing.path);
+        this.byPath.delete(existing.path);
+        this.events.emitConfigUpdate();
+    }
+}

--- a/controller/events.ts
+++ b/controller/events.ts
@@ -1,0 +1,30 @@
+import { EventEmitter } from 'events';
+import { LogRow, RunRecord } from './types';
+
+/**
+ * In-process event bus connecting the job runner / config registry to SSE clients.
+ *
+ * Events:
+ *  - 'run:update'    (run: RunRecord)                     — a run was created or changed status
+ *  - 'run:log'       ({ runId: number, lines: LogRow[] }) — new log lines for a running job
+ *  - 'config:update' ()                                   — the set of configs changed on disk
+ */
+export class ControllerEvents extends EventEmitter {
+    constructor() {
+        super();
+        // Every SSE client adds a listener per event; don't warn at the default 10
+        this.setMaxListeners(1000);
+    }
+
+    emitRunUpdate(run: RunRecord): void {
+        this.emit('run:update', run);
+    }
+
+    emitRunLogs(runId: number, lines: LogRow[]): void {
+        this.emit('run:log', { runId, lines });
+    }
+
+    emitConfigUpdate(): void {
+        this.emit('config:update');
+    }
+}

--- a/controller/index.ts
+++ b/controller/index.ts
@@ -4,6 +4,7 @@ import { Logger, LogLevel } from '../logger';
 import { ConfigRegistry } from './config-registry';
 import { ControllerEvents } from './events';
 import { JobRunner } from './job-runner';
+import { SlackNotifier } from './notifier';
 import { Scheduler } from './scheduler';
 import { createServer } from './server';
 import { ControllerStore } from './store';
@@ -62,6 +63,18 @@ export async function startController(opts: StartControllerOptions): Promise<voi
     }, logger.child('scheduler'));
 
     events.on('config:update', () => scheduler.sync(registry.list()));
+
+    if (opts.slackWebhookUrl) {
+        new SlackNotifier(
+            {
+                webhookUrl: opts.slackWebhookUrl,
+                notify: opts.slackNotify ?? 'all',
+                publicUrl: opts.publicUrl,
+            },
+            store,
+            logger.child('slack')
+        ).attach(events);
+    }
 
     await registry.start();
     scheduler.sync(registry.list());

--- a/controller/index.ts
+++ b/controller/index.ts
@@ -1,0 +1,113 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { Logger, LogLevel } from '../logger';
+import { ConfigRegistry } from './config-registry';
+import { ControllerEvents } from './events';
+import { JobRunner } from './job-runner';
+import { Scheduler } from './scheduler';
+import { createServer } from './server';
+import { ControllerStore } from './store';
+import { StartControllerOptions } from './types';
+
+export { StartControllerOptions } from './types';
+
+const LOG_PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+export async function startController(opts: StartControllerOptions): Promise<void> {
+    const logger = new Logger('Controller', {
+        level: LogLevel.INFO,
+        useTimestamp: true,
+        useColor: true,
+        prettyPrint: true,
+    });
+
+    if (!opts.databaseUrl) {
+        throw new Error('controller mode requires Postgres: pass --database-url or set DATABASE_URL');
+    }
+    if (opts.readWrite && !opts.configDir) {
+        throw new Error('--read-write requires --config-dir (where new configs are written)');
+    }
+    if (opts.configArgs.length === 0 && !(opts.readWrite && opts.configDir)) {
+        throw new Error('provide at least one config file or directory');
+    }
+    if (opts.configDir) {
+        fs.mkdirSync(path.resolve(opts.configDir), { recursive: true });
+    }
+
+    logger.section('DOC2VEC CONTROLLER');
+    logger.info(`Mode: ${opts.readWrite ? 'read-write' : 'read-only'}, max parallel jobs: ${opts.maxParallel}`);
+
+    const store = new ControllerStore(opts.databaseUrl, logger.child('store'));
+    await store.init();
+
+    const events = new ControllerEvents();
+    const runner = new JobRunner(store, events, { maxParallel: Math.max(opts.maxParallel, 1) }, logger.child('runner'));
+    const registry = new ConfigRegistry(
+        {
+            configArgs: opts.configArgs,
+            configDir: opts.configDir,
+            readWrite: opts.readWrite,
+            reloadIntervalSec: opts.reloadIntervalSec,
+        },
+        store,
+        events,
+        logger.child('registry')
+    );
+    const scheduler = new Scheduler(configId => {
+        const config = registry.get(configId);
+        if (!config) return;
+        runner.enqueue(config, 'scheduled').catch(err =>
+            logger.error(`Failed to enqueue scheduled run for '${config.name}':`, err)
+        );
+    }, logger.child('scheduler'));
+
+    events.on('config:update', () => scheduler.sync(registry.list()));
+
+    await registry.start();
+    scheduler.sync(registry.list());
+
+    const app = createServer({
+        store,
+        registry,
+        scheduler,
+        runner,
+        events,
+        readWrite: opts.readWrite,
+        logger: logger.child('api'),
+    });
+    const server = app.listen(opts.port, () => {
+        logger.info(`API and UI listening on http://localhost:${opts.port}`);
+    });
+
+    const pruneLogs = () => {
+        store.pruneOldLogs(opts.logRetentionDays)
+            .then(count => { if (count > 0) logger.info(`Pruned ${count} log row(s) older than ${opts.logRetentionDays} days`); })
+            .catch(err => logger.error('Log retention pruning failed:', err));
+    };
+    pruneLogs();
+    const pruneTimer = setInterval(pruneLogs, LOG_PRUNE_INTERVAL_MS);
+    pruneTimer.unref();
+
+    let shuttingDown = false;
+    const shutdown = (signal: string) => {
+        if (shuttingDown) return;
+        shuttingDown = true;
+        logger.info(`Received ${signal}, shutting down...`);
+        clearInterval(pruneTimer);
+        scheduler.stop();
+        registry.stop();
+        server.close();
+        runner.shutdown()
+            .then(() => store.close())
+            .then(() => {
+                logger.info('Shutdown complete');
+                process.exit(0);
+            })
+            .catch(err => {
+                logger.error('Error during shutdown:', err);
+                process.exit(1);
+            });
+    };
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
+    process.on('SIGINT', () => shutdown('SIGINT'));
+}

--- a/controller/job-runner.ts
+++ b/controller/job-runner.ts
@@ -1,0 +1,325 @@
+import { ChildProcess, spawn } from 'child_process';
+import * as path from 'path';
+import * as readline from 'readline';
+import { Logger } from '../logger';
+import { ControllerEvents } from './events';
+import { ControllerStore } from './store';
+import { ConfigRecord, ConflictError, LogRow, RunRecord, RunTrigger } from './types';
+
+const MAX_LOG_MESSAGE_BYTES = 8192;
+const LOG_FLUSH_LINES = 100;
+const LOG_FLUSH_MS = 500;
+const CANCEL_KILL_GRACE_MS = 10_000;
+const SHUTDOWN_GRACE_MS = 25_000;
+
+interface QueuedJob {
+    runId: number;
+    configId: number;
+    configPath: string;
+}
+
+interface ActiveJob {
+    runId: number;
+    configId: number;
+    child: ChildProcess;
+    seq: number;
+    buffer: LogRow[];
+    flushTimer: ReturnType<typeof setTimeout> | null;
+    warnCount: number;
+    errorCount: number;
+    sources: any[] | null;
+    cancelReason: 'user' | 'shutdown' | null;
+    killTimer: ReturnType<typeof setTimeout> | null;
+}
+
+export interface JobRunnerOptions {
+    maxParallel: number;
+    /**
+     * Command used to run a sync job for a config file. Defaults to spawning this
+     * same build's doc2vec.js with the `run` subcommand; overridable for tests.
+     */
+    commandFor?: (configPath: string) => { cmd: string; args: string[] };
+}
+
+/**
+ * Runs sync jobs as child processes with a global concurrency cap and a
+ * per-config lock (a config never has two simultaneous runs). Captures the
+ * child's structured log stream into Postgres and fans it out over SSE.
+ */
+export class JobRunner {
+    private queue: QueuedJob[] = [];
+    private active = new Map<number, ActiveJob>();       // by runId
+    private queuedConfigs = new Set<number>();
+    private activeConfigs = new Set<number>();
+    private shuttingDown = false;
+
+    constructor(
+        private store: ControllerStore,
+        private events: ControllerEvents,
+        private opts: JobRunnerOptions,
+        private logger: Logger
+    ) {}
+
+    isBusy(configId: number): boolean {
+        return this.queuedConfigs.has(configId) || this.activeConfigs.has(configId);
+    }
+
+    runningCount(): number {
+        return this.active.size;
+    }
+
+    async enqueue(config: ConfigRecord, trigger: RunTrigger): Promise<RunRecord> {
+        if (this.shuttingDown) {
+            throw new ConflictError('controller is shutting down');
+        }
+        if (this.isBusy(config.id)) {
+            if (trigger === 'scheduled') {
+                // Overlapping scheduled run: record it as skipped so the history shows why nothing happened
+                const run = await this.store.createRun(config.id, config.content_hash, trigger, 'skipped', 'previous run still queued or running');
+                this.events.emitRunUpdate(run);
+                this.logger.warn(`Skipped scheduled run for '${config.name}': previous run still in progress`);
+                return run;
+            }
+            throw new ConflictError('a run for this config is already queued or running');
+        }
+        if (config.parse_error) {
+            throw new ConflictError(`config is invalid: ${config.parse_error}`);
+        }
+
+        const run = await this.store.createRun(config.id, config.content_hash, trigger, 'queued');
+        this.queuedConfigs.add(config.id);
+        this.queue.push({ runId: run.id, configId: config.id, configPath: config.path });
+        this.events.emitRunUpdate(run);
+        this.pump();
+        return run;
+    }
+
+    private pump(): void {
+        while (!this.shuttingDown && this.active.size < this.opts.maxParallel && this.queue.length > 0) {
+            const job = this.queue.shift()!;
+            this.queuedConfigs.delete(job.configId);
+            this.activeConfigs.add(job.configId);
+            this.start(job).catch(async err => {
+                this.logger.error(`Failed to start run ${job.runId}:`, err);
+                this.activeConfigs.delete(job.configId);
+                this.active.delete(job.runId);
+                const run = await this.store.finishRun(job.runId, {
+                    status: 'failed',
+                    error: `failed to spawn job: ${err instanceof Error ? err.message : String(err)}`,
+                });
+                this.events.emitRunUpdate(run);
+                this.pump();
+            });
+        }
+    }
+
+    private commandFor(configPath: string): { cmd: string; args: string[] } {
+        if (this.opts.commandFor) return this.opts.commandFor(configPath);
+        // dist/controller/job-runner.js → dist/doc2vec.js
+        const scriptPath = path.resolve(__dirname, '..', 'doc2vec.js');
+        return { cmd: process.execPath, args: [scriptPath, 'run', configPath] };
+    }
+
+    private async start(job: QueuedJob): Promise<void> {
+        const { cmd, args } = this.commandFor(job.configPath);
+        this.logger.info(`Starting run ${job.runId}: ${cmd} ${args.join(' ')}`);
+
+        const child = spawn(cmd, args, {
+            env: { ...process.env, DOC2VEC_STRUCTURED_LOGS: '1' },
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+
+        const activeJob: ActiveJob = {
+            runId: job.runId,
+            configId: job.configId,
+            child,
+            seq: 0,
+            buffer: [],
+            flushTimer: null,
+            warnCount: 0,
+            errorCount: 0,
+            sources: null,
+            cancelReason: null,
+            killTimer: null,
+        };
+        this.active.set(job.runId, activeJob);
+
+        const run = await this.store.markRunStarted(job.runId, child.pid);
+        this.events.emitRunUpdate(run);
+
+        readline.createInterface({ input: child.stdout! }).on('line', line => this.handleLine(activeJob, line, false));
+        readline.createInterface({ input: child.stderr! }).on('line', line => this.handleLine(activeJob, line, true));
+
+        child.on('error', err => {
+            this.appendLog(activeJob, 'error', null, `spawn error: ${err.message}`);
+        });
+
+        child.on('close', (code, signal) => {
+            this.finish(activeJob, code, signal).catch(err =>
+                this.logger.error(`Failed to finalize run ${job.runId}:`, err)
+            );
+        });
+    }
+
+    private handleLine(aj: ActiveJob, raw: string, fromStderr: boolean): void {
+        if (!raw.trim()) return;
+        let level = fromStderr ? 'warn' : 'info';
+        let module: string | null = null;
+        let message = raw;
+        let ts = new Date().toISOString();
+
+        try {
+            const obj = JSON.parse(raw);
+            if (obj && typeof obj === 'object') {
+                ts = obj.ts || ts;
+                module = obj.module ?? null;
+                if (obj.event === 'run-summary') {
+                    aj.sources = Array.isArray(obj.sources) ? obj.sources : null;
+                    return;
+                } else if (obj.event === 'progress') {
+                    message = `${obj.title}: ${obj.current}/${obj.total}${obj.message ? ` — ${obj.message}` : ''}`;
+                    level = 'info';
+                } else if (obj.event === 'section') {
+                    message = `═══ ${obj.title} ═══`;
+                    level = 'info';
+                } else if (obj.msg !== undefined) {
+                    message = String(obj.msg);
+                    level = String(obj.level || level);
+                }
+            }
+        } catch {
+            // Not JSON (e.g. Chromium noise on stderr) — keep the raw line
+        }
+
+        if (level === 'warn') aj.warnCount++;
+        if (level === 'error') aj.errorCount++;
+        this.appendLog(aj, level, module, message, ts);
+    }
+
+    private appendLog(aj: ActiveJob, level: string, module: string | null, message: string, ts = new Date().toISOString()): void {
+        aj.buffer.push({
+            seq: ++aj.seq,
+            ts,
+            level,
+            module,
+            message: Buffer.byteLength(message) > MAX_LOG_MESSAGE_BYTES
+                ? message.slice(0, MAX_LOG_MESSAGE_BYTES) + '… [truncated]'
+                : message,
+        });
+        if (aj.buffer.length >= LOG_FLUSH_LINES) {
+            void this.flush(aj);
+        } else if (!aj.flushTimer) {
+            aj.flushTimer = setTimeout(() => void this.flush(aj), LOG_FLUSH_MS);
+        }
+    }
+
+    private async flush(aj: ActiveJob): Promise<void> {
+        if (aj.flushTimer) {
+            clearTimeout(aj.flushTimer);
+            aj.flushTimer = null;
+        }
+        if (aj.buffer.length === 0) return;
+        const rows = aj.buffer.splice(0, aj.buffer.length);
+        this.events.emitRunLogs(aj.runId, rows);
+        try {
+            await this.store.insertLogs(aj.runId, rows);
+        } catch (err) {
+            this.logger.error(`Failed to persist ${rows.length} log line(s) for run ${aj.runId}:`, err);
+        }
+    }
+
+    private async finish(aj: ActiveJob, code: number | null, signal: NodeJS.Signals | null): Promise<void> {
+        if (aj.killTimer) clearTimeout(aj.killTimer);
+        await this.flush(aj);
+
+        let status: RunRecord['status'];
+        let error: string | null = null;
+        if (aj.cancelReason === 'user') {
+            status = 'canceled';
+        } else if (aj.cancelReason === 'shutdown') {
+            status = 'failed';
+            error = 'controller shutdown';
+        } else if (code === 0) {
+            status = 'succeeded';
+        } else {
+            status = 'failed';
+            error = signal ? `terminated by signal ${signal}` : `exited with code ${code}`;
+            const failedSources = aj.sources?.filter(s => !s.ok) ?? [];
+            if (failedSources.length > 0) {
+                error = `${failedSources.length} source(s) failed: ${failedSources.map(s => s.product_name).join(', ')}`;
+            }
+        }
+
+        const run = await this.store.finishRun(aj.runId, {
+            status,
+            exitCode: code,
+            error,
+            stats: {
+                ...(aj.sources && { sources: aj.sources }),
+                warn_count: aj.warnCount,
+                error_count: aj.errorCount,
+            },
+        });
+
+        this.active.delete(aj.runId);
+        this.activeConfigs.delete(aj.configId);
+        this.logger.info(`Run ${aj.runId} finished: ${status}${error ? ` (${error})` : ''}`);
+        this.events.emitRunUpdate(run);
+        this.pump();
+    }
+
+    async cancel(runId: number): Promise<RunRecord> {
+        const queuedIndex = this.queue.findIndex(job => job.runId === runId);
+        if (queuedIndex >= 0) {
+            const [job] = this.queue.splice(queuedIndex, 1);
+            this.queuedConfigs.delete(job.configId);
+            const run = await this.store.finishRun(runId, { status: 'canceled', error: 'canceled while queued' });
+            this.events.emitRunUpdate(run);
+            return run;
+        }
+
+        const aj = this.active.get(runId);
+        if (!aj) {
+            throw new ConflictError('run is not queued or running');
+        }
+        aj.cancelReason = 'user';
+        aj.child.kill('SIGTERM');
+        aj.killTimer = setTimeout(() => {
+            if (this.active.has(runId)) aj.child.kill('SIGKILL');
+        }, CANCEL_KILL_GRACE_MS);
+        aj.killTimer.unref();
+        const run = await this.store.getRun(runId);
+        return run!;
+    }
+
+    async shutdown(): Promise<void> {
+        this.shuttingDown = true;
+
+        const queued = this.queue.splice(0, this.queue.length);
+        this.queuedConfigs.clear();
+        for (const job of queued) {
+            const run = await this.store.finishRun(job.runId, { status: 'canceled', error: 'controller shutdown' });
+            this.events.emitRunUpdate(run);
+        }
+
+        if (this.active.size === 0) return;
+        this.logger.info(`Waiting for ${this.active.size} running job(s) to terminate...`);
+        for (const aj of this.active.values()) {
+            aj.cancelReason = aj.cancelReason ?? 'shutdown';
+            aj.child.kill('SIGTERM');
+        }
+
+        const deadline = Date.now() + SHUTDOWN_GRACE_MS;
+        while (this.active.size > 0 && Date.now() < deadline) {
+            await new Promise(resolve => setTimeout(resolve, 250));
+        }
+        for (const aj of this.active.values()) {
+            this.logger.warn(`Run ${aj.runId} did not exit in time, sending SIGKILL`);
+            aj.child.kill('SIGKILL');
+        }
+        const killDeadline = Date.now() + 3000;
+        while (this.active.size > 0 && Date.now() < killDeadline) {
+            await new Promise(resolve => setTimeout(resolve, 100));
+        }
+    }
+}

--- a/controller/migrations.ts
+++ b/controller/migrations.ts
@@ -1,0 +1,52 @@
+/**
+ * Ordered schema migrations for the controller's Postgres database.
+ * Applied versions are tracked in d2v_schema_migrations; never edit an entry
+ * after it has shipped — append a new one instead.
+ */
+export const MIGRATIONS: string[] = [
+    // 1: initial schema
+    `
+    CREATE TABLE IF NOT EXISTS d2v_configs (
+        id             SERIAL PRIMARY KEY,
+        path           TEXT NOT NULL UNIQUE,
+        name           TEXT NOT NULL,
+        content        TEXT NOT NULL,
+        content_hash   TEXT NOT NULL,
+        schedule       TEXT,
+        source_summary JSONB NOT NULL DEFAULT '[]',
+        parse_error    TEXT,
+        enabled        BOOLEAN NOT NULL DEFAULT TRUE,
+        deleted_at     TIMESTAMPTZ,
+        created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS d2v_runs (
+        id          SERIAL PRIMARY KEY,
+        config_id   INT NOT NULL REFERENCES d2v_configs(id),
+        config_hash TEXT NOT NULL,
+        trigger     TEXT NOT NULL CHECK (trigger IN ('scheduled','manual')),
+        status      TEXT NOT NULL CHECK (status IN ('queued','running','succeeded','failed','skipped','canceled')),
+        pid         INT,
+        exit_code   INT,
+        error       TEXT,
+        stats       JSONB NOT NULL DEFAULT '{}',
+        queued_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        started_at  TIMESTAMPTZ,
+        finished_at TIMESTAMPTZ
+    );
+
+    CREATE INDEX IF NOT EXISTS d2v_runs_config_queued_idx ON d2v_runs (config_id, queued_at DESC);
+    CREATE INDEX IF NOT EXISTS d2v_runs_status_idx ON d2v_runs (status);
+
+    CREATE TABLE IF NOT EXISTS d2v_run_logs (
+        run_id  INT NOT NULL REFERENCES d2v_runs(id) ON DELETE CASCADE,
+        seq     BIGINT NOT NULL,
+        ts      TIMESTAMPTZ NOT NULL,
+        level   TEXT NOT NULL,
+        module  TEXT,
+        message TEXT NOT NULL,
+        PRIMARY KEY (run_id, seq)
+    );
+    `,
+];

--- a/controller/notifier.ts
+++ b/controller/notifier.ts
@@ -1,0 +1,116 @@
+import { Logger } from '../logger';
+import { ControllerEvents } from './events';
+import { ControllerStore } from './store';
+import { RunRecord } from './types';
+
+export interface SlackNotifierOptions {
+    webhookUrl: string;
+    notify: 'all' | 'failures';   // 'failures' also covers canceled runs
+    publicUrl?: string;           // e.g. https://doc2vec.is.solo.io — enables "View run" links
+}
+
+// Terminal statuses worth a notification. 'skipped' (overlapping schedule)
+// is deliberately excluded — it would be pure noise on busy schedules.
+const NOTIFIED_STATUSES: RunRecord['status'][] = ['succeeded', 'failed', 'canceled'];
+
+const STATUS_DECOR: Record<string, { emoji: string; verb: string }> = {
+    succeeded: { emoji: '✅', verb: 'succeeded' },
+    failed: { emoji: '❌', verb: 'failed' },
+    canceled: { emoji: '⚠️', verb: 'was canceled' },
+};
+
+function formatDuration(run: RunRecord): string | null {
+    if (!run.started_at || !run.finished_at) return null;
+    const seconds = (new Date(run.finished_at).getTime() - new Date(run.started_at).getTime()) / 1000;
+    if (seconds < 60) return `${Math.round(seconds)}s`;
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ${Math.round(seconds % 60)}s`;
+    return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+}
+
+/** Builds the Slack webhook payload (Block Kit) for a finished run. */
+export function buildRunMessage(run: RunRecord, configName: string, publicUrl?: string): Record<string, any> {
+    const decor = STATUS_DECOR[run.status] ?? { emoji: 'ℹ️', verb: run.status };
+    const sources = run.stats?.sources ?? [];
+    const failedSources = sources.filter(s => !s.ok);
+
+    let headline = `${decor.emoji} doc2vec sync *${configName}* ${decor.verb}`;
+    if (publicUrl) {
+        headline += ` — <${publicUrl.replace(/\/$/, '')}/runs/${run.id}|view run #${run.id}>`;
+    } else {
+        headline += ` (run #${run.id})`;
+    }
+
+    const lines: string[] = [];
+    if (sources.length > 0) {
+        lines.push(`${sources.length - failedSources.length}/${sources.length} sources ok`);
+    }
+    if (failedSources.length > 0) {
+        const shown = failedSources.slice(0, 5)
+            .map(s => `• *${s.product_name}*: ${s.error ?? 'failed'}`);
+        if (failedSources.length > 5) shown.push(`• …and ${failedSources.length - 5} more`);
+        lines.push(shown.join('\n'));
+    }
+    if (run.error && failedSources.length === 0) {
+        lines.push(run.error);
+    }
+
+    const meta: string[] = [`trigger: ${run.trigger}`];
+    const duration = formatDuration(run);
+    if (duration) meta.push(`duration: ${duration}`);
+    if (run.stats?.warn_count) meta.push(`warnings: ${run.stats.warn_count}`);
+    if (run.stats?.error_count) meta.push(`errors: ${run.stats.error_count}`);
+
+    return {
+        text: `doc2vec sync ${configName} ${decor.verb}`,   // fallback for notifications
+        blocks: [
+            {
+                type: 'section',
+                text: { type: 'mrkdwn', text: [headline, ...lines].join('\n') },
+            },
+            {
+                type: 'context',
+                elements: [{ type: 'mrkdwn', text: meta.join(' · ') }],
+            },
+        ],
+    };
+}
+
+/**
+ * Posts a Slack message (incoming webhook) whenever a run reaches a terminal
+ * status. Subscribes to the same event bus that feeds the UI, so every path
+ * that finishes a run — success, failure, cancel — is covered.
+ */
+export class SlackNotifier {
+    constructor(
+        private opts: SlackNotifierOptions,
+        private store: ControllerStore,
+        private logger: Logger
+    ) {}
+
+    attach(events: ControllerEvents): void {
+        events.on('run:update', (run: RunRecord) => {
+            this.maybeNotify(run).catch(err =>
+                this.logger.error(`Failed to send Slack notification for run ${run.id}:`, err)
+            );
+        });
+        this.logger.info(`Slack notifications enabled (${this.opts.notify})`);
+    }
+
+    private async maybeNotify(run: RunRecord): Promise<void> {
+        if (!NOTIFIED_STATUSES.includes(run.status)) return;
+        if (this.opts.notify === 'failures' && run.status === 'succeeded') return;
+
+        const config = await this.store.getConfig(run.config_id);
+        const payload = buildRunMessage(run, config?.name ?? `config ${run.config_id}`, this.opts.publicUrl);
+
+        const response = await fetch(this.opts.webhookUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+            this.logger.warn(`Slack webhook returned ${response.status}: ${await response.text().catch(() => '')}`);
+        }
+    }
+}

--- a/controller/scheduler.ts
+++ b/controller/scheduler.ts
@@ -1,0 +1,56 @@
+import { Cron } from 'croner';
+import { Logger } from '../logger';
+import { ConfigRecord } from './types';
+
+/**
+ * One croner Cron per config that has a valid schedule. Reconciled against the
+ * registry's current config list whenever configs change on disk.
+ */
+export class Scheduler {
+    private crons = new Map<number, Cron>();
+
+    constructor(
+        private onTrigger: (configId: number) => void,
+        private logger: Logger
+    ) {}
+
+    sync(configs: ConfigRecord[]): void {
+        const seen = new Set<number>();
+        for (const config of configs) {
+            if (!config.schedule || config.parse_error || !config.enabled || config.deleted_at) continue;
+            seen.add(config.id);
+
+            const existing = this.crons.get(config.id);
+            if (existing && existing.getPattern() === config.schedule) continue;
+            existing?.stop();
+
+            try {
+                const cron = new Cron(config.schedule, { name: `config-${config.id}` }, () => {
+                    this.onTrigger(config.id);
+                });
+                this.crons.set(config.id, cron);
+                this.logger.info(`Scheduled '${config.name}' (${config.schedule}), next run ${cron.nextRun()?.toISOString() ?? 'never'}`);
+            } catch (err) {
+                this.crons.delete(config.id);
+                this.logger.warn(`Failed to schedule '${config.name}' with '${config.schedule}':`, err);
+            }
+        }
+
+        for (const [id, cron] of this.crons) {
+            if (!seen.has(id)) {
+                cron.stop();
+                this.crons.delete(id);
+                this.logger.info(`Unscheduled config ${id}`);
+            }
+        }
+    }
+
+    nextRun(configId: number): string | null {
+        return this.crons.get(configId)?.nextRun()?.toISOString() ?? null;
+    }
+
+    stop(): void {
+        for (const cron of this.crons.values()) cron.stop();
+        this.crons.clear();
+    }
+}

--- a/controller/server.ts
+++ b/controller/server.ts
@@ -1,0 +1,285 @@
+import express, { NextFunction, Request, Response } from 'express';
+import * as fs from 'fs';
+import * as path from 'path';
+import { Logger } from '../logger';
+import { ConfigRegistry, isValidCron, parseConfigMeta } from './config-registry';
+import { ControllerEvents } from './events';
+import { JobRunner } from './job-runner';
+import { Scheduler } from './scheduler';
+import { ControllerStore } from './store';
+import { ConflictError, LogRow, NotFoundError, RunRecord, RunStatus, ValidationError } from './types';
+
+const SSE_HEARTBEAT_MS = 15_000;
+
+export interface ServerDeps {
+    store: ControllerStore;
+    registry: ConfigRegistry;
+    scheduler: Scheduler;
+    runner: JobRunner;
+    events: ControllerEvents;
+    readWrite: boolean;
+    logger: Logger;
+}
+
+function getVersion(): string {
+    try {
+        return require('../../package.json').version;
+    } catch {
+        return 'unknown';
+    }
+}
+
+function sseInit(res: Response): void {
+    res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+        'X-Accel-Buffering': 'no',
+    });
+    res.write(':ok\n\n');
+}
+
+function sseSend(res: Response, event: string, data: unknown): void {
+    res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+export function createServer(deps: ServerDeps): express.Express {
+    const { store, registry, scheduler, runner, events, readWrite, logger } = deps;
+    const app = express();
+    app.use(express.json({ limit: '2mb' }));
+
+    const requireReadWrite = (_req: Request, res: Response, next: NextFunction) => {
+        if (!readWrite) {
+            res.status(403).json({ error: 'controller is running in read-only mode' });
+            return;
+        }
+        next();
+    };
+
+    const parseId = (raw: string): number => {
+        const id = Number(raw);
+        if (!Number.isInteger(id) || id <= 0) throw new ValidationError('invalid id');
+        return id;
+    };
+
+    const enrichConfig = (config: any, lastRuns: Map<number, RunRecord>) => ({
+        ...config,
+        next_run: scheduler.nextRun(config.id),
+        last_run: lastRuns.get(config.id) ?? null,
+        busy: runner.isBusy(config.id),
+    });
+
+    // ------------------------------------------------------------------ meta
+
+    app.get('/api/health', (_req, res) => {
+        res.json({ status: 'ok', mode: readWrite ? 'rw' : 'ro', version: getVersion() });
+    });
+
+    // ------------------------------------------------------------------ configs
+
+    app.get('/api/configs', async (_req, res) => {
+        const lastRuns = await store.getLastRuns();
+        res.json(registry.list().map(c => enrichConfig(c, lastRuns)));
+    });
+
+    app.get('/api/configs/:id', async (req, res) => {
+        const config = registry.get(parseId(String(req.params.id)));
+        if (!config) throw new NotFoundError('config not found');
+        const lastRuns = await store.getLastRuns();
+        res.json(enrichConfig(config, lastRuns));
+    });
+
+    app.post('/api/configs', requireReadWrite, async (req, res) => {
+        const { filename, content } = req.body ?? {};
+        if (typeof filename !== 'string' || typeof content !== 'string') {
+            throw new ValidationError('body must contain filename and content strings');
+        }
+        const record = await registry.create(filename, content);
+        res.status(201).json(record);
+    });
+
+    app.put('/api/configs/:id', requireReadWrite, async (req, res) => {
+        const { content, baseHash } = req.body ?? {};
+        if (typeof content !== 'string' || typeof baseHash !== 'string') {
+            throw new ValidationError('body must contain content and baseHash strings');
+        }
+        const record = await registry.update(parseId(String(req.params.id)), content, baseHash);
+        res.json(record);
+    });
+
+    app.delete('/api/configs/:id', requireReadWrite, async (req, res) => {
+        await registry.delete(parseId(String(req.params.id)));
+        res.status(204).end();
+    });
+
+    app.post('/api/configs/validate', (req, res) => {
+        const { content } = req.body ?? {};
+        if (typeof content !== 'string') {
+            throw new ValidationError('body must contain a content string');
+        }
+        const meta = parseConfigMeta(content, 'config.yaml');
+        res.json({
+            valid: !meta.parseError,
+            error: meta.parseError,
+            name: meta.name,
+            schedule: meta.schedule,
+            schedule_valid: meta.schedule ? isValidCron(meta.schedule) : null,
+            sources: meta.sourceSummary,
+        });
+    });
+
+    app.post('/api/configs/:id/run', async (req, res) => {
+        const config = registry.get(parseId(String(req.params.id)));
+        if (!config) throw new NotFoundError('config not found');
+        const run = await runner.enqueue(config, 'manual');
+        res.status(202).json(run);
+    });
+
+    app.get('/api/configs/:id/stats', async (req, res) => {
+        const id = parseId(String(req.params.id));
+        if (!registry.get(id)) throw new NotFoundError('config not found');
+        const days = Number(req.query.days) || 30;
+        res.json(await store.getConfigStats(id, days));
+    });
+
+    // ------------------------------------------------------------------ runs
+
+    app.get('/api/runs', async (req, res) => {
+        res.json(await store.listRuns({
+            configId: req.query.configId !== undefined ? parseId(String(req.query.configId)) : undefined,
+            status: req.query.status !== undefined ? String(req.query.status) as RunStatus : undefined,
+            limit: req.query.limit !== undefined ? Number(req.query.limit) : undefined,
+            before: req.query.before !== undefined ? Number(req.query.before) : undefined,
+        }));
+    });
+
+    app.get('/api/runs/:id', async (req, res) => {
+        const run = await store.getRun(parseId(String(req.params.id)));
+        if (!run) throw new NotFoundError('run not found');
+        const config = registry.get(run.config_id) ?? await store.getConfig(run.config_id);
+        res.json({ ...run, config_name: config?.name ?? null });
+    });
+
+    app.get('/api/runs/:id/logs', async (req, res) => {
+        const id = parseId(String(req.params.id));
+        if (!await store.getRun(id)) throw new NotFoundError('run not found');
+        const afterSeq = Number(req.query.afterSeq) || 0;
+        const limit = Number(req.query.limit) || 1000;
+        res.json(await store.getLogs(id, afterSeq, limit));
+    });
+
+    app.post('/api/runs/:id/cancel', async (req, res) => {
+        res.json(await runner.cancel(parseId(String(req.params.id))));
+    });
+
+    // ------------------------------------------------------------------ SSE
+
+    app.get('/api/events', (req, res) => {
+        sseInit(res);
+        const onRunUpdate = (run: RunRecord) => sseSend(res, 'run:update', run);
+        const onConfigUpdate = () => sseSend(res, 'config:update', {});
+        events.on('run:update', onRunUpdate);
+        events.on('config:update', onConfigUpdate);
+        const heartbeat = setInterval(() => res.write(':hb\n\n'), SSE_HEARTBEAT_MS);
+        req.on('close', () => {
+            clearInterval(heartbeat);
+            events.off('run:update', onRunUpdate);
+            events.off('config:update', onConfigUpdate);
+        });
+    });
+
+    app.get('/api/runs/:id/logs/stream', async (req, res) => {
+        const id = parseId(String(req.params.id));
+        const run = await store.getRun(id);
+        if (!run) throw new NotFoundError('run not found');
+
+        sseInit(res);
+        let lastSeq = Number(req.query.afterSeq) || 0;
+        let replayDone = false;
+        const pending: LogRow[] = [];
+
+        const sendRow = (row: LogRow) => {
+            if (row.seq > lastSeq) {
+                lastSeq = row.seq;
+                sseSend(res, 'log', row);
+            }
+        };
+        const onLog = (payload: { runId: number; lines: LogRow[] }) => {
+            if (payload.runId !== id) return;
+            if (!replayDone) {
+                pending.push(...payload.lines);
+                return;
+            }
+            payload.lines.forEach(sendRow);
+        };
+        const onRunUpdate = (updated: RunRecord) => {
+            if (updated.id !== id) return;
+            sseSend(res, 'run:update', updated);
+            if (['succeeded', 'failed', 'canceled', 'skipped'].includes(updated.status)) {
+                sseSend(res, 'end', { status: updated.status });
+            }
+        };
+        events.on('run:log', onLog);
+        events.on('run:update', onRunUpdate);
+
+        // Replay history from the DB, then flush anything that streamed in meanwhile
+        try {
+            let batch: LogRow[];
+            do {
+                batch = await store.getLogs(id, lastSeq, 5000);
+                batch.forEach(sendRow);
+            } while (batch.length === 5000);
+        } finally {
+            replayDone = true;
+            pending.forEach(sendRow);
+            pending.length = 0;
+        }
+
+        const current = await store.getRun(id);
+        if (current && ['succeeded', 'failed', 'canceled', 'skipped'].includes(current.status)) {
+            sseSend(res, 'end', { status: current.status });
+        }
+
+        const heartbeat = setInterval(() => res.write(':hb\n\n'), SSE_HEARTBEAT_MS);
+        req.on('close', () => {
+            clearInterval(heartbeat);
+            events.off('run:log', onLog);
+            events.off('run:update', onRunUpdate);
+        });
+    });
+
+    // ------------------------------------------------------------------ static UI
+
+    const uiDir = path.resolve(__dirname, '..', 'ui');
+    if (fs.existsSync(path.join(uiDir, 'index.html'))) {
+        app.use(express.static(uiDir));
+        // SPA fallback for client-side routes (anything that's not /api)
+        app.use((req, res, next) => {
+            if (req.method === 'GET' && !req.path.startsWith('/api')) {
+                res.sendFile(path.join(uiDir, 'index.html'));
+                return;
+            }
+            next();
+        });
+    } else {
+        logger.warn(`UI assets not found at ${uiDir} — API only (build them with 'npm run build:ui')`);
+    }
+
+    // ------------------------------------------------------------------ errors
+
+    app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+        if (res.headersSent) return;
+        if (err instanceof ValidationError) {
+            res.status(400).json({ error: err.message });
+        } else if (err instanceof NotFoundError) {
+            res.status(404).json({ error: err.message });
+        } else if (err instanceof ConflictError) {
+            res.status(409).json({ error: err.message });
+        } else {
+            logger.error('Unhandled API error:', err);
+            res.status(500).json({ error: 'internal error' });
+        }
+    });
+
+    return app;
+}

--- a/controller/store.ts
+++ b/controller/store.ts
@@ -1,0 +1,268 @@
+import { Pool } from 'pg';
+import { Logger } from '../logger';
+import { MIGRATIONS } from './migrations';
+import {
+    ConfigRecord,
+    LogRow,
+    RunRecord,
+    RunStatsPayload,
+    RunStatus,
+    RunTrigger,
+    SourceSummary
+} from './types';
+
+export interface UpsertConfigInput {
+    path: string;
+    name: string;
+    content: string;
+    contentHash: string;
+    schedule: string | null;
+    sourceSummary: SourceSummary[];
+    parseError: string | null;
+}
+
+/**
+ * All Postgres access for controller mode: configs, runs, and run logs.
+ */
+export class ControllerStore {
+    private pool: Pool;
+    private logger: Logger;
+
+    constructor(databaseUrl: string, logger: Logger) {
+        this.pool = new Pool({ connectionString: databaseUrl, max: 10 });
+        this.logger = logger;
+    }
+
+    async init(): Promise<void> {
+        await this.migrate();
+        await this.markOrphanedRuns();
+    }
+
+    async close(): Promise<void> {
+        await this.pool.end();
+    }
+
+    private async migrate(): Promise<void> {
+        const client = await this.pool.connect();
+        try {
+            await client.query(`CREATE TABLE IF NOT EXISTS d2v_schema_migrations (
+                version INT PRIMARY KEY,
+                applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )`);
+            const { rows } = await client.query('SELECT COALESCE(MAX(version), 0) AS version FROM d2v_schema_migrations');
+            const current = Number(rows[0].version);
+            for (let i = current; i < MIGRATIONS.length; i++) {
+                const version = i + 1;
+                this.logger.info(`Applying migration ${version}`);
+                await client.query('BEGIN');
+                try {
+                    await client.query(MIGRATIONS[i]);
+                    await client.query('INSERT INTO d2v_schema_migrations (version) VALUES ($1)', [version]);
+                    await client.query('COMMIT');
+                } catch (err) {
+                    await client.query('ROLLBACK');
+                    throw err;
+                }
+            }
+        } finally {
+            client.release();
+        }
+    }
+
+    /** Runs left 'queued'/'running' by a previous controller process can never finish — fail them. */
+    private async markOrphanedRuns(): Promise<void> {
+        const { rowCount } = await this.pool.query(
+            `UPDATE d2v_runs
+             SET status = 'failed', error = 'controller restarted while run was in progress', finished_at = NOW()
+             WHERE status IN ('queued', 'running')`
+        );
+        if (rowCount) {
+            this.logger.warn(`Marked ${rowCount} orphaned run(s) from a previous controller process as failed`);
+        }
+    }
+
+    // ------------------------------------------------------------------ configs
+
+    async upsertConfig(input: UpsertConfigInput): Promise<ConfigRecord> {
+        const { rows } = await this.pool.query(
+            `INSERT INTO d2v_configs (path, name, content, content_hash, schedule, source_summary, parse_error)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)
+             ON CONFLICT (path) DO UPDATE SET
+                name = EXCLUDED.name,
+                content = EXCLUDED.content,
+                content_hash = EXCLUDED.content_hash,
+                schedule = EXCLUDED.schedule,
+                source_summary = EXCLUDED.source_summary,
+                parse_error = EXCLUDED.parse_error,
+                deleted_at = NULL,
+                updated_at = NOW()
+             RETURNING *`,
+            [input.path, input.name, input.content, input.contentHash, input.schedule,
+             JSON.stringify(input.sourceSummary), input.parseError]
+        );
+        return rows[0];
+    }
+
+    async markConfigDeleted(path: string): Promise<void> {
+        await this.pool.query('UPDATE d2v_configs SET deleted_at = NOW(), updated_at = NOW() WHERE path = $1', [path]);
+    }
+
+    async listConfigs(includeDeleted = false): Promise<ConfigRecord[]> {
+        const { rows } = await this.pool.query(
+            `SELECT * FROM d2v_configs ${includeDeleted ? '' : 'WHERE deleted_at IS NULL'} ORDER BY name`
+        );
+        return rows;
+    }
+
+    async getConfig(id: number): Promise<ConfigRecord | null> {
+        const { rows } = await this.pool.query('SELECT * FROM d2v_configs WHERE id = $1', [id]);
+        return rows[0] ?? null;
+    }
+
+    // ------------------------------------------------------------------ runs
+
+    async createRun(configId: number, configHash: string, trigger: RunTrigger, status: RunStatus, error?: string): Promise<RunRecord> {
+        const terminal = status === 'skipped';
+        const { rows } = await this.pool.query(
+            `INSERT INTO d2v_runs (config_id, config_hash, trigger, status, error, finished_at)
+             VALUES ($1, $2, $3, $4, $5, ${terminal ? 'NOW()' : 'NULL'})
+             RETURNING *`,
+            [configId, configHash, trigger, status, error ?? null]
+        );
+        return rows[0];
+    }
+
+    async markRunStarted(runId: number, pid: number | undefined): Promise<RunRecord> {
+        const { rows } = await this.pool.query(
+            `UPDATE d2v_runs SET status = 'running', pid = $2, started_at = NOW() WHERE id = $1 RETURNING *`,
+            [runId, pid ?? null]
+        );
+        return rows[0];
+    }
+
+    async finishRun(runId: number, outcome: { status: RunStatus; exitCode?: number | null; error?: string | null; stats?: RunStatsPayload }): Promise<RunRecord> {
+        const { rows } = await this.pool.query(
+            `UPDATE d2v_runs
+             SET status = $2, exit_code = $3, error = $4, stats = $5, finished_at = NOW()
+             WHERE id = $1 RETURNING *`,
+            [runId, outcome.status, outcome.exitCode ?? null, outcome.error ?? null, JSON.stringify(outcome.stats ?? {})]
+        );
+        return rows[0];
+    }
+
+    async getRun(runId: number): Promise<RunRecord | null> {
+        const { rows } = await this.pool.query('SELECT * FROM d2v_runs WHERE id = $1', [runId]);
+        return rows[0] ?? null;
+    }
+
+    async listRuns(filter: { configId?: number; status?: RunStatus; limit?: number; before?: number } = {}): Promise<RunRecord[]> {
+        const conditions: string[] = [];
+        const params: any[] = [];
+        if (filter.configId !== undefined) {
+            params.push(filter.configId);
+            conditions.push(`config_id = $${params.length}`);
+        }
+        if (filter.status !== undefined) {
+            params.push(filter.status);
+            conditions.push(`status = $${params.length}`);
+        }
+        if (filter.before !== undefined) {
+            params.push(filter.before);
+            conditions.push(`id < $${params.length}`);
+        }
+        params.push(Math.min(filter.limit ?? 50, 500));
+        const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+        const { rows } = await this.pool.query(
+            `SELECT * FROM d2v_runs ${where} ORDER BY id DESC LIMIT $${params.length}`,
+            params
+        );
+        return rows;
+    }
+
+    /** Latest run per config, for the dashboard list. */
+    async getLastRuns(): Promise<Map<number, RunRecord>> {
+        const { rows } = await this.pool.query(
+            `SELECT DISTINCT ON (config_id) * FROM d2v_runs ORDER BY config_id, id DESC`
+        );
+        return new Map(rows.map((r: RunRecord) => [r.config_id, r]));
+    }
+
+    // ------------------------------------------------------------------ logs
+
+    async insertLogs(runId: number, rows: LogRow[]): Promise<void> {
+        if (rows.length === 0) return;
+        const values: any[] = [];
+        const placeholders = rows.map((row, i) => {
+            const base = i * 6;
+            values.push(runId, row.seq, row.ts, row.level, row.module, row.message);
+            return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6})`;
+        });
+        await this.pool.query(
+            `INSERT INTO d2v_run_logs (run_id, seq, ts, level, module, message) VALUES ${placeholders.join(', ')}
+             ON CONFLICT DO NOTHING`,
+            values
+        );
+    }
+
+    async getLogs(runId: number, afterSeq = 0, limit = 1000): Promise<LogRow[]> {
+        const { rows } = await this.pool.query(
+            `SELECT seq, ts, level, module, message FROM d2v_run_logs
+             WHERE run_id = $1 AND seq > $2 ORDER BY seq LIMIT $3`,
+            [runId, afterSeq, Math.min(limit, 5000)]
+        );
+        return rows.map((r: any) => ({ ...r, seq: Number(r.seq) }));
+    }
+
+    async pruneOldLogs(retentionDays: number): Promise<number> {
+        const { rowCount } = await this.pool.query(
+            `DELETE FROM d2v_run_logs USING d2v_runs
+             WHERE d2v_run_logs.run_id = d2v_runs.id
+               AND d2v_runs.finished_at < NOW() - make_interval(days => $1)`,
+            [retentionDays]
+        );
+        return rowCount ?? 0;
+    }
+
+    // ------------------------------------------------------------------ stats
+
+    /** Daily run counts by status + duration stats, for the config stats page. */
+    async getConfigStats(configId: number, days: number): Promise<{
+        daily: Array<{ day: string; status: string; count: number; avg_duration_s: number | null }>;
+        recentDurations: Array<{ id: number; status: string; started_at: string; duration_s: number }>;
+        totals: { total: number; succeeded: number; failed: number; skipped: number; canceled: number };
+    }> {
+        const boundedDays = Math.min(Math.max(days, 1), 365);
+        const [daily, recent, totals] = await Promise.all([
+            this.pool.query(
+                `SELECT date_trunc('day', queued_at)::date::text AS day, status, COUNT(*)::int AS count,
+                        AVG(EXTRACT(EPOCH FROM (finished_at - started_at)))::float AS avg_duration_s
+                 FROM d2v_runs
+                 WHERE config_id = $1 AND queued_at > NOW() - make_interval(days => $2)
+                 GROUP BY 1, 2 ORDER BY 1`,
+                [configId, boundedDays]
+            ),
+            this.pool.query(
+                `SELECT id, status, started_at, EXTRACT(EPOCH FROM (finished_at - started_at))::float AS duration_s
+                 FROM d2v_runs
+                 WHERE config_id = $1 AND status IN ('succeeded', 'failed') AND started_at IS NOT NULL AND finished_at IS NOT NULL
+                 ORDER BY id DESC LIMIT 50`,
+                [configId]
+            ),
+            this.pool.query(
+                `SELECT COUNT(*)::int AS total,
+                        COUNT(*) FILTER (WHERE status = 'succeeded')::int AS succeeded,
+                        COUNT(*) FILTER (WHERE status = 'failed')::int AS failed,
+                        COUNT(*) FILTER (WHERE status = 'skipped')::int AS skipped,
+                        COUNT(*) FILTER (WHERE status = 'canceled')::int AS canceled
+                 FROM d2v_runs
+                 WHERE config_id = $1 AND queued_at > NOW() - make_interval(days => $2)`,
+                [configId, boundedDays]
+            ),
+        ]);
+        return {
+            daily: daily.rows,
+            recentDurations: recent.rows.reverse(),
+            totals: totals.rows[0],
+        };
+    }
+}

--- a/controller/types.ts
+++ b/controller/types.ts
@@ -1,0 +1,93 @@
+// Shared types for controller mode
+
+export interface StartControllerOptions {
+    configArgs: string[];          // config files and/or directories from the CLI
+    databaseUrl?: string;
+    port: number;
+    readWrite: boolean;
+    configDir?: string;            // where UI-created configs are written (read-write mode)
+    maxParallel: number;
+    reloadIntervalSec: number;
+    logRetentionDays: number;
+}
+
+export interface SourceSummary {
+    type: string;
+    product_name: string;
+    version?: string;
+}
+
+export interface ConfigRecord {
+    id: number;
+    path: string;
+    name: string;
+    content: string;               // raw YAML, ${ENV} placeholders unresolved
+    content_hash: string;
+    schedule: string | null;
+    source_summary: SourceSummary[];
+    parse_error: string | null;    // set when the YAML is invalid — config shown as broken in the UI
+    enabled: boolean;
+    deleted_at: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
+export type RunTrigger = 'scheduled' | 'manual';
+export type RunStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'skipped' | 'canceled';
+
+export interface RunRecord {
+    id: number;
+    config_id: number;
+    config_hash: string;
+    trigger: RunTrigger;
+    status: RunStatus;
+    pid: number | null;
+    exit_code: number | null;
+    error: string | null;
+    stats: RunStatsPayload;
+    queued_at: string;
+    started_at: string | null;
+    finished_at: string | null;
+}
+
+export interface RunStatsPayload {
+    sources?: Array<{
+        product_name: string;
+        type: string;
+        version: string;
+        duration_ms: number;
+        ok: boolean;
+        error?: string;
+    }>;
+    warn_count?: number;
+    error_count?: number;
+}
+
+export interface LogRow {
+    seq: number;
+    ts: string;
+    level: string;
+    module: string | null;
+    message: string;
+}
+
+export class ConflictError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ConflictError';
+    }
+}
+
+export class NotFoundError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'NotFoundError';
+    }
+}
+
+export class ValidationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ValidationError';
+    }
+}

--- a/controller/types.ts
+++ b/controller/types.ts
@@ -9,6 +9,9 @@ export interface StartControllerOptions {
     maxParallel: number;
     reloadIntervalSec: number;
     logRetentionDays: number;
+    slackWebhookUrl?: string;      // Slack incoming webhook — notifies when runs finish
+    slackNotify?: 'all' | 'failures';
+    publicUrl?: string;            // externally reachable base URL, used for links in notifications
 }
 
 export interface SourceSummary {

--- a/doc2vec.ts
+++ b/doc2vec.ts
@@ -1909,6 +1909,9 @@ if (require.main === module) {
         .option('--max-parallel <n>', 'maximum number of sync jobs running at once', (v: string) => parseInt(v, 10), 1)
         .option('--reload-interval <seconds>', 'how often to re-poll config files for changes', (v: string) => parseInt(v, 10), 30)
         .option('--log-retention-days <days>', 'delete run logs older than this many days', (v: string) => parseInt(v, 10), 14)
+        .option('--slack-webhook-url <url>', 'Slack incoming webhook for run notifications (or SLACK_WEBHOOK_URL env var)')
+        .option('--slack-notify <mode>', "which runs to notify about: 'all' or 'failures'", 'all')
+        .option('--public-url <url>', 'externally reachable base URL, used for links in notifications (or PUBLIC_URL env var)')
         .action(async (configs: string[], options: any) => {
             // Lazy-require so the one-shot path doesn't load express/pg
             const { startController } = require('./controller') as typeof import('./controller');
@@ -1922,6 +1925,9 @@ if (require.main === module) {
                     maxParallel: options.maxParallel,
                     reloadIntervalSec: options.reloadInterval,
                     logRetentionDays: options.logRetentionDays,
+                    slackWebhookUrl: options.slackWebhookUrl || process.env.SLACK_WEBHOOK_URL,
+                    slackNotify: options.slackNotify === 'failures' ? 'failures' : 'all',
+                    publicUrl: options.publicUrl || process.env.PUBLIC_URL,
                 });
             } catch (err) {
                 console.error(err instanceof Error ? err.message : err);

--- a/doc2vec.ts
+++ b/doc2vec.ts
@@ -28,7 +28,8 @@ import {
     DocumentChunk,
     BrokenLink,
     EmbeddingConfig,
-    MarkdownStoreConfig
+    MarkdownStoreConfig,
+    SourceRunStats
 } from './types';
 import { S3Client, ListObjectsV2Command, GetObjectCommand } from '@aws-sdk/client-s3';
 import { MarkdownStore } from './markdown-store';
@@ -174,34 +175,57 @@ export class Doc2Vec {
         return parsedValue;
     }
 
-    public async run(): Promise<void> {
+    public async run(): Promise<SourceRunStats[]> {
         // Initialize Postgres markdown store table if configured
         if (this.markdownStore) {
             await this.markdownStore.init();
         }
 
         this.logger.section('PROCESSING SOURCES');
-        
+
+        const runStats: SourceRunStats[] = [];
+
         for (const sourceConfig of this.config.sources) {
             const sourceLogger = this.logger.child(`source:${sourceConfig.product_name}`);
-            
+
             sourceLogger.info(`Processing ${sourceConfig.type} source for ${sourceConfig.product_name}@${sourceConfig.version}`);
-            
-            if (sourceConfig.type === 'github') {
-                await this.processGithubRepo(sourceConfig, sourceLogger);
-            } else if (sourceConfig.type === 'website') {
-                await this.processWebsite(sourceConfig, sourceLogger);
-            } else if (sourceConfig.type === 'local_directory') {
-                await this.processLocalDirectory(sourceConfig, sourceLogger);
-            } else if (sourceConfig.type === 'code') {
-                await this.processCodeSource(sourceConfig, sourceLogger);
-            } else if (sourceConfig.type === 'zendesk') {
-                await this.processZendesk(sourceConfig, sourceLogger);
-            } else if (sourceConfig.type === 's3') {
-                await this.processS3(sourceConfig, sourceLogger);
-            } else {
-                sourceLogger.error(`Unknown source type: ${(sourceConfig as any).type}`);
+
+            const startTime = Date.now();
+            let ok = true;
+            let errorMessage: string | undefined;
+
+            try {
+                if (sourceConfig.type === 'github') {
+                    await this.processGithubRepo(sourceConfig, sourceLogger);
+                } else if (sourceConfig.type === 'website') {
+                    await this.processWebsite(sourceConfig, sourceLogger);
+                } else if (sourceConfig.type === 'local_directory') {
+                    await this.processLocalDirectory(sourceConfig, sourceLogger);
+                } else if (sourceConfig.type === 'code') {
+                    await this.processCodeSource(sourceConfig, sourceLogger);
+                } else if (sourceConfig.type === 'zendesk') {
+                    await this.processZendesk(sourceConfig, sourceLogger);
+                } else if (sourceConfig.type === 's3') {
+                    await this.processS3(sourceConfig, sourceLogger);
+                } else {
+                    ok = false;
+                    errorMessage = `Unknown source type: ${(sourceConfig as any).type}`;
+                    sourceLogger.error(errorMessage);
+                }
+            } catch (error) {
+                ok = false;
+                errorMessage = error instanceof Error ? error.message : String(error);
+                sourceLogger.error(`Failed to process ${sourceConfig.type} source for ${sourceConfig.product_name}:`, error);
             }
+
+            runStats.push({
+                product_name: sourceConfig.product_name,
+                type: sourceConfig.type,
+                version: sourceConfig.version,
+                duration_ms: Date.now() - startTime,
+                ok,
+                ...(errorMessage && { error: errorMessage })
+            });
         }
 
         // Close the Postgres markdown store connection pool
@@ -210,6 +234,9 @@ export class Doc2Vec {
         }
 
         this.logger.section('PROCESSING COMPLETE');
+        this.logger.event('run-summary', { sources: runStats });
+
+        return runStats;
     }
 
     private async fetchAndProcessGitHubIssues(repo: string, sourceConfig: GithubSourceConfig, dbConnection: DatabaseConnection, logger: Logger): Promise<void> {
@@ -1841,14 +1868,62 @@ export class Doc2Vec {
     }
 }
 
-if (require.main === module) {
-    const configPath = process.argv[2] || 'config.yaml';
+function runOneShot(configPath: string): void {
     if (!fs.existsSync(configPath)) {
         console.error('Please provide a valid path to a YAML config file.');
         process.exit(1);
     }
     const doc2Vec = new Doc2Vec(configPath);
     doc2Vec.run()
-        .then(() => process.exit(0))
+        .then((stats) => process.exit(stats.some(s => !s.ok) ? 1 : 0))
         .catch((err) => { console.error(err); process.exit(1); });
+}
+
+if (require.main === module) {
+    const { Command } = require('commander') as typeof import('commander');
+    const program = new Command();
+
+    program
+        .name('doc2vec')
+        .description('Crawl documentation sources and store embeddings in vector databases')
+        // Legacy invocation: `doc2vec [config.yaml]` runs a one-shot sync
+        .argument('[config]', 'path to a YAML config file', 'config.yaml')
+        .action((configPath: string) => runOneShot(configPath));
+
+    program
+        .command('run <config>')
+        .description('Run a one-shot sync for a config file (what the controller spawns)')
+        .action((configPath: string) => runOneShot(configPath));
+
+    program
+        .command('controller [configs...]')
+        .description('Run as a long-lived controller: schedule sync jobs per config file, persist runs in Postgres, serve a web UI')
+        .option('--database-url <url>', 'Postgres connection string (or DATABASE_URL env var)')
+        .option('--port <port>', 'HTTP port for the API/UI (or PORT env var)', (v: string) => parseInt(v, 10))
+        .option('--read-write', 'allow creating/editing configs from the UI (default: read-only)', false)
+        .option('--config-dir <dir>', 'directory where UI-created configs are written (required with --read-write)')
+        .option('--max-parallel <n>', 'maximum number of sync jobs running at once', (v: string) => parseInt(v, 10), 1)
+        .option('--reload-interval <seconds>', 'how often to re-poll config files for changes', (v: string) => parseInt(v, 10), 30)
+        .option('--log-retention-days <days>', 'delete run logs older than this many days', (v: string) => parseInt(v, 10), 14)
+        .action(async (configs: string[], options: any) => {
+            // Lazy-require so the one-shot path doesn't load express/pg
+            const { startController } = require('./controller') as typeof import('./controller');
+            try {
+                await startController({
+                    configArgs: configs,
+                    databaseUrl: options.databaseUrl || process.env.DATABASE_URL,
+                    port: options.port || (process.env.PORT ? parseInt(process.env.PORT, 10) : 8080),
+                    readWrite: options.readWrite,
+                    configDir: options.configDir,
+                    maxParallel: options.maxParallel,
+                    reloadIntervalSec: options.reloadInterval,
+                    logRetentionDays: options.logRetentionDays,
+                });
+            } catch (err) {
+                console.error(err instanceof Error ? err.message : err);
+                process.exit(1);
+            }
+        });
+
+    program.parse();
 } 

--- a/doc2vec.ts
+++ b/doc2vec.ts
@@ -682,7 +682,11 @@ export class Doc2Vec {
     }
 
     private writeBrokenLinksReport(): void {
-        const reportPath = path.join(this.configDir, '404.yaml');
+        // The default (next to the config file) breaks when the config lives on
+        // a read-only mount (e.g. a Kubernetes ConfigMap in controller mode) —
+        // DOC2VEC_REPORT_DIR points the report somewhere writable instead.
+        const reportDir = process.env.DOC2VEC_REPORT_DIR || this.configDir;
+        const reportPath = path.join(reportDir, '404.yaml');
         const orderedEntries = Object.entries(this.brokenLinksByWebsite)
             .sort(([a], [b]) => a.localeCompare(b));
         const reportPayload = orderedEntries.map(([website, links]) => ({

--- a/logger.ts
+++ b/logger.ts
@@ -26,6 +26,36 @@ enum LogLevel {
   }
   
   /**
+   * When DOC2VEC_STRUCTURED_LOGS=1 (set by the controller when spawning sync jobs),
+   * every log line is emitted as a single JSON object so a parent process can parse
+   * the stream reliably. Human-formatted output is suppressed in this mode.
+   */
+  const STRUCTURED = process.env.DOC2VEC_STRUCTURED_LOGS === '1';
+
+  function emitStructured(payload: Record<string, any>, useStderr = false): void {
+    const line = JSON.stringify(payload);
+    if (useStderr) {
+      process.stderr.write(line + '\n');
+    } else {
+      process.stdout.write(line + '\n');
+    }
+  }
+
+  function stringifyArg(arg: any): string {
+    if (arg instanceof Error) {
+      return `${arg.message}${arg.stack ? `\n${arg.stack}` : ''}`;
+    }
+    if (typeof arg === 'object' && arg !== null) {
+      try {
+        return JSON.stringify(arg);
+      } catch (e) {
+        return '[Unserializable Object]';
+      }
+    }
+    return String(arg);
+  }
+
+  /**
    * Basic color functions that don't rely on external packages
    */
   const colors = {
@@ -136,8 +166,24 @@ enum LogLevel {
      * @param message Message to log
      * @param args Additional arguments
      */
+    private emitJson(level: string, message: string, args: any[], useStderr = false): void {
+      const msg = args.length > 0
+        ? `${message} ${args.map(stringifyArg).join(' ')}`
+        : message;
+      emitStructured({
+        ts: new Date().toISOString(),
+        level,
+        module: this.moduleName,
+        msg
+      }, useStderr);
+    }
+
     debug(message: string, ...args: any[]): void {
       if (this.config.level <= LogLevel.DEBUG) {
+        if (STRUCTURED) {
+          this.emitJson('debug', message, args);
+          return;
+        }
         const formattedMessage = this.formatMessage('DEBUG', message, args);
         console.log(this.colorize(LogLevel.DEBUG, formattedMessage));
       }
@@ -151,6 +197,10 @@ enum LogLevel {
      */
     info(message: string, ...args: any[]): void {
       if (this.config.level <= LogLevel.INFO) {
+        if (STRUCTURED) {
+          this.emitJson('info', message, args);
+          return;
+        }
         const formattedMessage = this.formatMessage('INFO', message, args);
         console.log(this.colorize(LogLevel.INFO, formattedMessage));
       }
@@ -164,6 +214,10 @@ enum LogLevel {
      */
     warn(message: string, ...args: any[]): void {
       if (this.config.level <= LogLevel.WARN) {
+        if (STRUCTURED) {
+          this.emitJson('warn', message, args, true);
+          return;
+        }
         const formattedMessage = this.formatMessage('WARN', message, args);
         console.warn(this.colorize(LogLevel.WARN, formattedMessage));
       }
@@ -177,9 +231,28 @@ enum LogLevel {
      */
     error(message: string, ...args: any[]): void {
       if (this.config.level <= LogLevel.ERROR) {
+        if (STRUCTURED) {
+          this.emitJson('error', message, args, true);
+          return;
+        }
         const formattedMessage = this.formatMessage('ERROR', message, args);
         console.error(this.colorize(LogLevel.ERROR, formattedMessage));
       }
+    }
+
+    /**
+     * Emit a structured event (e.g. run-summary). In structured mode this prints a
+     * machine-parseable JSON line; otherwise it logs the payload at info level.
+     *
+     * @param name Event name
+     * @param data Event payload
+     */
+    event(name: string, data: Record<string, any> = {}): void {
+      if (STRUCTURED) {
+        emitStructured({ event: name, ts: new Date().toISOString(), ...data });
+        return;
+      }
+      this.info(`[event:${name}]`, data);
     }
   
     /**
@@ -200,6 +273,10 @@ enum LogLevel {
      */
     section(title: string): Logger {
       if (this.config.level <= LogLevel.INFO) {
+        if (STRUCTURED) {
+          emitStructured({ event: 'section', ts: new Date().toISOString(), module: this.moduleName, title });
+          return this;
+        }
         const separator = '='.repeat(Math.max(80 - title.length - 4, 10));
         const message = `${separator} ${title} ${separator}`;
         console.log(this.colorize(LogLevel.INFO, message));
@@ -217,11 +294,23 @@ enum LogLevel {
     progress(title: string, total: number) {
       let current = 0;
       const startTime = Date.now();
-      
+      // In structured mode, throttle progress lines to at most one per second so a
+      // large crawl doesn't flood the parent process / database with log rows.
+      let lastStructuredEmit = 0;
+
       const update = (increment = 1, message?: string) => {
         if (this.config.level > LogLevel.INFO) return;
-        
+
         current += increment;
+
+        if (STRUCTURED) {
+          const now = Date.now();
+          if (now - lastStructuredEmit >= 1000 || current === total) {
+            lastStructuredEmit = now;
+            emitStructured({ event: 'progress', ts: new Date().toISOString(), module: this.moduleName, title, current, total, message });
+          }
+          return;
+        }
         const percentage = Math.min(Math.floor((current / total) * 100), 100);
         const elapsed = (Date.now() - startTime) / 1000;
         let rate = current / elapsed;
@@ -243,9 +332,14 @@ enum LogLevel {
       
       const complete = (message = 'Completed') => {
         if (this.config.level > LogLevel.INFO) return;
-        
+
         const elapsed = (Date.now() - startTime) / 1000;
         const rate = total / elapsed;
+
+        if (STRUCTURED) {
+          emitStructured({ event: 'progress', ts: new Date().toISOString(), module: this.moduleName, title, current: total, total, message: `${message} in ${elapsed.toFixed(2)}s`, done: true });
+          return;
+        }
         
         console.log(this.colorize(
           LogLevel.INFO,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "doc2vec",
-    "version": "2.10.0",
+    "version": "2.10.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "doc2vec",
-            "version": "2.10.0",
+            "version": "2.10.5",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.1004.0",
@@ -18,7 +18,10 @@
                 "better-sqlite3": "^11.9.1",
                 "chalk": "^5.4.1",
                 "cheerio": "^1.0.0-rc.12",
+                "commander": "^15.0.0",
+                "croner": "^10.0.1",
                 "dotenv": "^16.3.1",
+                "express": "^5.2.1",
                 "js-yaml": "^4.1.0",
                 "jsdom": "^26.0.0",
                 "mammoth": "^1.11.0",
@@ -38,6 +41,7 @@
             },
             "devDependencies": {
                 "@types/better-sqlite3": "^7.6.12",
+                "@types/express": "^5.0.6",
                 "@types/js-yaml": "^4.0.9",
                 "@types/jsdom": "^21.1.7",
                 "@types/node": "^20.10.0",
@@ -3000,6 +3004,17 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/body-parser": {
+            "version": "1.19.6",
+            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+            "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/connect": "*",
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/chai": {
             "version": "5.2.3",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -3008,6 +3023,16 @@
             "dependencies": {
                 "@types/deep-eql": "*",
                 "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/connect": {
+            "version": "3.4.38",
+            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+            "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
             }
         },
         "node_modules/@types/deep-eql": {
@@ -3021,6 +3046,38 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "dev": true
+        },
+        "node_modules/@types/express": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+            "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/body-parser": "*",
+                "@types/express-serve-static-core": "^5.0.0",
+                "@types/serve-static": "^2"
+            }
+        },
+        "node_modules/@types/express-serve-static-core": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+            "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*",
+                "@types/send": "*"
+            }
+        },
+        "node_modules/@types/http-errors": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+            "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/js-yaml": {
             "version": "4.0.9",
@@ -3067,6 +3124,20 @@
                 "pg-types": "^2.2.0"
             }
         },
+        "node_modules/@types/qs": {
+            "version": "6.15.1",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+            "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/range-parser": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/sanitize-html": {
             "version": "2.13.0",
             "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.13.0.tgz",
@@ -3074,6 +3145,27 @@
             "dev": true,
             "dependencies": {
                 "htmlparser2": "^8.0.0"
+            }
+        },
+        "node_modules/@types/send": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/serve-static": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+            "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/http-errors": "*",
+                "@types/node": "*"
             }
         },
         "node_modules/@types/tough-cookie": {
@@ -3223,6 +3315,44 @@
             },
             "engines": {
                 "node": ">=6.5"
+            }
+        },
+        "node_modules/accepts": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/accepts/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/accepts/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/acorn": {
@@ -3497,6 +3627,59 @@
             "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
             "license": "MIT"
         },
+        "node_modules/body-parser": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+            "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "^3.1.2",
+                "content-type": "^2.0.0",
+                "debug": "^4.4.3",
+                "http-errors": "^2.0.1",
+                "iconv-lite": "^0.7.2",
+                "on-finished": "^2.4.1",
+                "qs": "^6.15.2",
+                "raw-body": "^3.0.2",
+                "type-is": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/body-parser/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/body-parser/node_modules/iconv-lite": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -3539,6 +3722,15 @@
                 "node": "*"
             }
         },
+        "node_modules/bytes": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -3549,6 +3741,22 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/callsites": {
@@ -3702,6 +3910,55 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/commander": {
+            "version": "15.0.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+            "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/content-disposition": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+            "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/content-type": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie-signature": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.6.0"
+            }
+        },
         "node_modules/core-util-is": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -3738,6 +3995,25 @@
             "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
             "dev": true
+        },
+        "node_modules/croner": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
+            "integrity": "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==",
+            "funding": [
+                {
+                    "type": "other",
+                    "url": "https://paypal.me/hexagonpp"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/hexagon"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0"
+            }
         },
         "node_modules/css-select": {
             "version": "5.1.0",
@@ -3900,6 +4176,15 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/depd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/detect-libc": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4013,10 +4298,25 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "license": "MIT"
+        },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/encoding-sniffer": {
             "version": "0.2.0",
@@ -4161,6 +4461,12 @@
                 "node": ">=6"
             }
         },
+        "node_modules/escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "license": "MIT"
+        },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -4229,6 +4535,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/event-target-shim": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -4252,6 +4567,74 @@
             "dev": true,
             "engines": {
                 "node": ">=12.0.0"
+            }
+        },
+        "node_modules/express": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "^2.0.0",
+                "body-parser": "^2.2.1",
+                "content-disposition": "^1.0.0",
+                "content-type": "^1.0.5",
+                "cookie": "^0.7.1",
+                "cookie-signature": "^1.2.1",
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "finalhandler": "^2.1.0",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "merge-descriptors": "^2.0.0",
+                "mime-types": "^3.0.0",
+                "on-finished": "^2.4.1",
+                "once": "^1.4.0",
+                "parseurl": "^1.3.3",
+                "proxy-addr": "^2.0.7",
+                "qs": "^6.14.0",
+                "range-parser": "^1.2.1",
+                "router": "^2.2.0",
+                "send": "^1.1.0",
+                "serve-static": "^2.2.0",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/express/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/extract-zip": {
@@ -4339,6 +4722,27 @@
             "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
             "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
         },
+        "node_modules/finalhandler": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/follow-redirects": {
             "version": "1.15.9",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
@@ -4389,6 +4793,24 @@
             },
             "engines": {
                 "node": ">= 12.20"
+            }
+        },
+        "node_modules/forwarded": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/fresh": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/fs-constants": {
@@ -4591,6 +5013,26 @@
                 "entities": "^4.4.0"
             }
         },
+        "node_modules/http-errors": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/http-proxy-agent": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4696,6 +5138,15 @@
                 "node": ">= 12"
             }
         },
+        "node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -4721,6 +5172,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
             "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+        },
+        "node_modules/is-promise": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+            "license": "MIT"
         },
         "node_modules/isarray": {
             "version": "1.0.0",
@@ -5027,6 +5484,27 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/media-typer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/merge-descriptors": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/mime-db": {
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -5102,6 +5580,15 @@
             "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
             "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
         },
+        "node_modules/negotiator": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/netmask": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
@@ -5174,6 +5661,18 @@
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.19.tgz",
             "integrity": "sha512-94bcyI3RsqiZufXjkr3ltkI86iEl+I7uiHVDtcq9wJUTwYQJ5odHDeSzkkrRzi80jJ8MaeZgqKjH1bAWAFw9bA=="
         },
+        "node_modules/object-inspect": {
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/obug": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -5183,6 +5682,18 @@
                 "https://github.com/sponsors/sxzz",
                 "https://opencollective.com/debug"
             ]
+        },
+        "node_modules/on-finished": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "license": "MIT",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/once": {
             "version": "1.4.0",
@@ -5344,6 +5855,15 @@
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
+        "node_modules/parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -5351,6 +5871,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-to-regexp": {
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+            "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/pathe": {
@@ -5576,6 +6106,19 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/proxy-addr": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "license": "MIT",
+            "dependencies": {
+                "forwarded": "0.2.0",
+                "ipaddr.js": "1.9.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/proxy-agent": {
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
@@ -5650,6 +6193,66 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/qs": {
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/range-parser": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+            "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/raw-body": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/raw-body/node_modules/iconv-lite": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/rc": {
@@ -5739,6 +6342,22 @@
                 "fsevents": "~2.3.2"
             }
         },
+        "node_modules/router": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+            "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "is-promise": "^4.0.0",
+                "parseurl": "^1.3.3",
+                "path-to-regexp": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
         "node_modules/rrweb-cssom": {
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -5804,11 +6423,159 @@
                 "node": ">=10"
             }
         },
+        "node_modules/send": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/send/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/send/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/serve-static": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+            "license": "MIT",
+            "dependencies": {
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
             "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
             "license": "MIT"
+        },
+        "node_modules/setprototypeof": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "license": "ISC"
+        },
+        "node_modules/side-channel": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/siginfo": {
             "version": "2.0.0",
@@ -6002,6 +6769,15 @@
             "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
             "dev": true
         },
+        "node_modules/statuses": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/std-env": {
             "version": "3.10.0",
             "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -6180,6 +6956,15 @@
             "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.85.tgz",
             "integrity": "sha512-DTjUVvxckL1fIoPSb3KE7ISNtkWSawZdpfxGxwiIrZoO6EbHVDXXUIlIuWympPaeS+BLGyggozX/HTMsRAdsoA=="
         },
+        "node_modules/toidentifier": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
         "node_modules/tough-cookie": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -6272,6 +7057,62 @@
                 "@mixmark-io/domino": "^2.2.0"
             }
         },
+        "node_modules/type-is": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+            "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^2.0.0",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/type-is/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/type-is/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/type-is/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/typed-query-selector": {
             "version": "2.12.0",
             "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
@@ -6311,6 +7152,15 @@
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
             "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
         },
+        "node_modules/unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6321,6 +7171,15 @@
             "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
             "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
             "dev": true
+        },
+        "node_modules/vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/vitest": {
             "version": "4.0.18",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,12 @@
     ],
     "scripts": {
         "build": "tsc && chmod 755 dist/doc2vec.js",
+        "build:ui": "npm --prefix ui ci && npm --prefix ui run build",
         "start": "node dist/doc2vec.js",
         "test": "vitest run",
         "test:watch": "vitest",
         "test:coverage": "vitest run --coverage",
-        "prepublishOnly": "npm run build",
+        "prepublishOnly": "npm run build && npm run build:ui",
         "prepare": "npm run build"
     },
     "keywords": [],
@@ -38,7 +39,10 @@
         "better-sqlite3": "^11.9.1",
         "chalk": "^5.4.1",
         "cheerio": "^1.0.0-rc.12",
+        "commander": "^15.0.0",
+        "croner": "^10.0.1",
         "dotenv": "^16.3.1",
+        "express": "^5.2.1",
         "js-yaml": "^4.1.0",
         "jsdom": "^26.0.0",
         "mammoth": "^1.11.0",
@@ -55,6 +59,7 @@
     },
     "devDependencies": {
         "@types/better-sqlite3": "^7.6.12",
+        "@types/express": "^5.0.6",
         "@types/js-yaml": "^4.0.9",
         "@types/jsdom": "^21.1.7",
         "@types/node": "^20.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "doc2vec",
-    "version": "2.10.6",
+    "version": "2.11.0",
     "type": "commonjs",
     "description": "",
     "main": "dist/doc2vec.js",

--- a/tests/content-processor.test.ts
+++ b/tests/content-processor.test.ts
@@ -944,6 +944,29 @@ describe('ContentProcessor', () => {
             database_config: { type: 'sqlite', params: {} }
         };
 
+        it('should abort the whole crawl when the browser cannot launch (after one retry)', async () => {
+            const puppeteerModule = await import('puppeteer');
+            const launchSpy = vi.spyOn(puppeteerModule.default, 'launch')
+                .mockRejectedValue(new Error('Failed to launch the browser process!'));
+
+            const visited = new Set<string>();
+            const processContent = vi.fn().mockResolvedValue(true);
+
+            // Fake timers to skip the 5s pause between the two launch attempts
+            vi.useFakeTimers();
+            const crawlPromise = processor.crawlWebsite('https://example.com', websiteConfig, processContent, testLogger, visited);
+            // Attach the rejection expectation before advancing time so the
+            // rejection isn't treated as unhandled
+            const assertion = expect(crawlPromise).rejects.toThrow(/browser failed to launch twice/);
+            await vi.advanceTimersByTimeAsync(6000);
+            await assertion;
+            vi.useRealTimers();
+
+            // Exactly two attempts (initial + one retry), not one per queued URL
+            expect(launchSpy).toHaveBeenCalledTimes(2);
+            expect(processContent).not.toHaveBeenCalled();
+        });
+
         it('should skip already visited URLs', async () => {
             vi.spyOn(processor as any, 'processPage').mockResolvedValue({ content: '# Content', links: [], finalUrl: 'https://example.com' });
 

--- a/tests/controller-notifier.test.ts
+++ b/tests/controller-notifier.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'events';
+import { buildRunMessage, SlackNotifier } from '../controller/notifier';
+import { RunRecord } from '../controller/types';
+
+function makeLogger(): any {
+    const l: any = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), section: vi.fn(), event: vi.fn() };
+    l.child = vi.fn(() => makeLogger());
+    return l;
+}
+
+function makeRun(overrides: Partial<RunRecord> = {}): RunRecord {
+    return {
+        id: 42,
+        config_id: 7,
+        config_hash: 'h',
+        trigger: 'scheduled',
+        status: 'succeeded',
+        pid: null,
+        exit_code: 0,
+        error: null,
+        stats: {
+            sources: [
+                { product_name: 'istio', type: 'website', version: 'latest', duration_ms: 60000, ok: true },
+                { product_name: 'helm', type: 'website', version: 'latest', duration_ms: 30000, ok: true },
+            ],
+            warn_count: 0,
+            error_count: 0,
+        },
+        queued_at: '2026-07-08T00:30:00Z',
+        started_at: '2026-07-08T00:30:01Z',
+        finished_at: '2026-07-08T01:12:31Z',
+        ...overrides,
+    };
+}
+
+/** Flushes the promise chain kicked off by an event handler. */
+const settle = () => new Promise(resolve => setTimeout(resolve, 0));
+
+describe('buildRunMessage', () => {
+    it('describes a successful run with duration and source count', () => {
+        const message = buildRunMessage(makeRun(), 'qdrant-sync', 'https://doc2vec.is.solo.io');
+        const text = JSON.stringify(message);
+        expect(message.text).toBe('doc2vec sync qdrant-sync succeeded');
+        expect(text).toContain('✅');
+        expect(text).toContain('2/2 sources ok');
+        expect(text).toContain('42m 30s');
+        expect(text).toContain('https://doc2vec.is.solo.io/runs/42');
+    });
+
+    it('lists failed sources with their errors', () => {
+        const run = makeRun({
+            status: 'failed',
+            exit_code: 1,
+            error: '1 source(s) failed: istio',
+            stats: {
+                sources: [
+                    { product_name: 'istio', type: 'website', version: 'latest', duration_ms: 5000, ok: false, error: 'browser failed to launch twice' },
+                    { product_name: 'helm', type: 'website', version: 'latest', duration_ms: 30000, ok: true },
+                ],
+                warn_count: 3,
+                error_count: 94,
+            },
+        });
+        const text = JSON.stringify(buildRunMessage(run, 'qdrant-sync'));
+        expect(text).toContain('❌');
+        expect(text).toContain('1/2 sources ok');
+        expect(text).toContain('*istio*: browser failed to launch twice');
+        expect(text).toContain('errors: 94');
+    });
+
+    it('truncates long failed-source lists', () => {
+        const sources = Array.from({ length: 8 }, (_, i) => ({
+            product_name: `src-${i}`, type: 'website', version: '1', duration_ms: 1, ok: false, error: 'boom',
+        }));
+        const text = JSON.stringify(buildRunMessage(makeRun({ status: 'failed', stats: { sources } }), 'c'));
+        expect(text).toContain('…and 3 more');
+    });
+
+    it('falls back to run id when no public URL is configured', () => {
+        const text = JSON.stringify(buildRunMessage(makeRun(), 'c'));
+        expect(text).toContain('run #42');
+        expect(text).not.toContain('/runs/42|');
+    });
+});
+
+describe('SlackNotifier', () => {
+    let events: any;
+    let store: any;
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        events = new EventEmitter();
+        store = { getConfig: vi.fn(async () => ({ id: 7, name: 'qdrant-sync' })) };
+        fetchMock = vi.fn(async () => ({ ok: true, status: 200, text: async () => '' }));
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    function makeNotifier(notify: 'all' | 'failures' = 'all') {
+        const notifier = new SlackNotifier(
+            { webhookUrl: 'https://hooks.slack.com/services/T/B/X', notify },
+            store,
+            makeLogger()
+        );
+        notifier.attach(events);
+        return notifier;
+    }
+
+    it('posts to the webhook when a run succeeds', async () => {
+        makeNotifier();
+        events.emit('run:update', makeRun());
+        await settle();
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toBe('https://hooks.slack.com/services/T/B/X');
+        expect(JSON.parse(init.body)).toMatchObject({ text: 'doc2vec sync qdrant-sync succeeded' });
+    });
+
+    it('ignores non-terminal and skipped statuses', async () => {
+        makeNotifier();
+        for (const status of ['queued', 'running', 'skipped'] as const) {
+            events.emit('run:update', makeRun({ status }));
+        }
+        await settle();
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('failures mode skips successes but reports failed and canceled runs', async () => {
+        makeNotifier('failures');
+        events.emit('run:update', makeRun({ status: 'succeeded' }));
+        events.emit('run:update', makeRun({ status: 'failed' }));
+        events.emit('run:update', makeRun({ status: 'canceled' }));
+        await settle();
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('survives webhook failures without throwing', async () => {
+        fetchMock.mockRejectedValueOnce(new Error('network down'));
+        makeNotifier();
+        events.emit('run:update', makeRun());
+        await settle();
+        // A second run still notifies
+        events.emit('run:update', makeRun({ id: 43 }));
+        await settle();
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+});

--- a/tests/controller-registry.test.ts
+++ b/tests/controller-registry.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ConfigRegistry, hashContent, isValidCron, parseConfigMeta } from '../controller/config-registry';
+import { ConflictError, ValidationError } from '../controller/types';
+
+const VALID_YAML = `
+name: my-config
+schedule: "0 2 * * *"
+sources:
+  - type: website
+    product_name: demo
+    version: latest
+`;
+
+function makeLogger(): any {
+    const l: any = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), section: vi.fn(), event: vi.fn() };
+    l.child = vi.fn(() => makeLogger());
+    return l;
+}
+
+function makeStore(): any {
+    let nextId = 1;
+    const byPath = new Map<string, any>();
+    return {
+        upsertConfig: vi.fn(async (input: any) => {
+            const existing = byPath.get(input.path);
+            const record = {
+                id: existing?.id ?? nextId++,
+                path: input.path,
+                name: input.name,
+                content: input.content,
+                content_hash: input.contentHash,
+                schedule: input.schedule,
+                source_summary: input.sourceSummary,
+                parse_error: input.parseError,
+                enabled: true,
+                deleted_at: null,
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+            };
+            byPath.set(input.path, record);
+            return record;
+        }),
+        markConfigDeleted: vi.fn(async (p: string) => { byPath.delete(p); }),
+    };
+}
+
+function makeEvents(): any {
+    return { emitConfigUpdate: vi.fn(), emitRunUpdate: vi.fn(), emitRunLogs: vi.fn() };
+}
+
+describe('parseConfigMeta', () => {
+    it('extracts name, schedule and source summary', () => {
+        const meta = parseConfigMeta(VALID_YAML, '/x/my.yaml');
+        expect(meta.name).toBe('my-config');
+        expect(meta.schedule).toBe('0 2 * * *');
+        expect(meta.sourceSummary).toEqual([{ type: 'website', product_name: 'demo', version: 'latest' }]);
+        expect(meta.parseError).toBeNull();
+    });
+
+    it('falls back to the file basename when name is missing', () => {
+        const meta = parseConfigMeta('sources:\n  - type: website\n    product_name: p\n', '/x/istio-docs.yaml');
+        expect(meta.name).toBe('istio-docs');
+    });
+
+    it('reports invalid YAML instead of throwing', () => {
+        const meta = parseConfigMeta('sources: [unclosed', '/x/bad.yaml');
+        expect(meta.parseError).toBeTruthy();
+    });
+
+    it('reports a missing sources array', () => {
+        const meta = parseConfigMeta('name: nope\n', '/x/no-sources.yaml');
+        expect(meta.parseError).toMatch(/no sources/);
+    });
+
+    it('rejects an invalid cron schedule', () => {
+        const meta = parseConfigMeta('schedule: "not a cron"\nsources:\n  - type: website\n    product_name: p\n', '/x/bad-cron.yaml');
+        expect(meta.parseError).toMatch(/invalid cron/);
+        expect(meta.schedule).toBeNull();
+    });
+
+    it('never substitutes ${ENV} placeholders', () => {
+        process.env.REGISTRY_TEST_SECRET = 'supersecret';
+        const yamlWithSecret = 'sources:\n  - type: zendesk\n    product_name: z\n    api_token: ${REGISTRY_TEST_SECRET}\n';
+        const meta = parseConfigMeta(yamlWithSecret, '/x/secret.yaml');
+        expect(meta.parseError).toBeNull();
+        // The raw content is what gets stored/displayed; parseConfigMeta must not resolve env vars
+        expect(yamlWithSecret).toContain('${REGISTRY_TEST_SECRET}');
+        expect(JSON.stringify(meta)).not.toContain('supersecret');
+        delete process.env.REGISTRY_TEST_SECRET;
+    });
+});
+
+describe('isValidCron', () => {
+    it('accepts standard cron expressions', () => {
+        expect(isValidCron('*/5 * * * *')).toBe(true);
+        expect(isValidCron('0 2 * * *')).toBe(true);
+    });
+    it('rejects garbage', () => {
+        expect(isValidCron('not a cron')).toBe(false);
+    });
+});
+
+describe('ConfigRegistry', () => {
+    let dir: string;
+    let store: any;
+    let events: any;
+    let registry: ConfigRegistry;
+
+    beforeEach(() => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'd2v-registry-'));
+        store = makeStore();
+        events = makeEvents();
+    });
+
+    afterEach(() => {
+        registry?.stop();
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    function makeRegistry(args: string[], readWrite = false, configDir?: string) {
+        registry = new ConfigRegistry(
+            { configArgs: args, configDir, readWrite, reloadIntervalSec: 3600 },
+            store,
+            events,
+            makeLogger()
+        );
+        return registry;
+    }
+
+    it('loads config files and directories on start', async () => {
+        fs.writeFileSync(path.join(dir, 'a.yaml'), VALID_YAML);
+        fs.writeFileSync(path.join(dir, 'b.yml'), VALID_YAML.replace('my-config', 'other'));
+        fs.writeFileSync(path.join(dir, 'ignored.txt'), 'nope');
+        await makeRegistry([dir]).start();
+
+        expect(registry.list()).toHaveLength(2);
+        expect(registry.list().map(c => c.name).sort()).toEqual(['my-config', 'other']);
+        expect(events.emitConfigUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    it('detects content changes by hash on re-sync', async () => {
+        const file = path.join(dir, 'a.yaml');
+        fs.writeFileSync(file, VALID_YAML);
+        await makeRegistry([file]).start();
+        expect(store.upsertConfig).toHaveBeenCalledTimes(1);
+
+        await registry.sync();
+        expect(store.upsertConfig).toHaveBeenCalledTimes(1); // unchanged → no upsert
+
+        fs.writeFileSync(file, VALID_YAML.replace('0 2 * * *', '0 3 * * *'));
+        await registry.sync();
+        expect(store.upsertConfig).toHaveBeenCalledTimes(2);
+        expect(registry.list()[0].schedule).toBe('0 3 * * *');
+    });
+
+    it('soft-deletes configs whose file disappears', async () => {
+        const file = path.join(dir, 'a.yaml');
+        fs.writeFileSync(file, VALID_YAML);
+        await makeRegistry([dir]).start();
+        expect(registry.list()).toHaveLength(1);
+
+        fs.unlinkSync(file);
+        await registry.sync();
+        expect(registry.list()).toHaveLength(0);
+        expect(store.markConfigDeleted).toHaveBeenCalledWith(file);
+    });
+
+    it('keeps invalid configs visible with a parse_error', async () => {
+        fs.writeFileSync(path.join(dir, 'broken.yaml'), 'sources: [unclosed');
+        await makeRegistry([dir]).start();
+        expect(registry.list()).toHaveLength(1);
+        expect(registry.list()[0].parse_error).toBeTruthy();
+    });
+
+    describe('read-write mode', () => {
+        it('creates a new config file in the config dir', async () => {
+            await makeRegistry([], true, dir).start();
+            const record = await registry.create('new.yaml', VALID_YAML);
+            expect(record.name).toBe('my-config');
+            expect(fs.readFileSync(path.join(dir, 'new.yaml'), 'utf8')).toBe(VALID_YAML);
+        });
+
+        it('rejects path-traversal filenames', async () => {
+            await makeRegistry([], true, dir).start();
+            await expect(registry.create('../evil.yaml', VALID_YAML)).rejects.toThrow(ValidationError);
+            await expect(registry.create('no-extension', VALID_YAML)).rejects.toThrow(ValidationError);
+        });
+
+        it('rejects invalid content on create', async () => {
+            await makeRegistry([], true, dir).start();
+            await expect(registry.create('bad.yaml', 'nope: true')).rejects.toThrow(ValidationError);
+        });
+
+        it('updates with optimistic concurrency on the content hash', async () => {
+            fs.writeFileSync(path.join(dir, 'a.yaml'), VALID_YAML);
+            await makeRegistry([], true, dir).start();
+            const config = registry.list()[0];
+
+            const newContent = VALID_YAML.replace('my-config', 'renamed');
+            const updated = await registry.update(config.id, newContent, config.content_hash);
+            expect(updated.name).toBe('renamed');
+
+            // Stale base hash → conflict
+            await expect(registry.update(config.id, VALID_YAML, config.content_hash)).rejects.toThrow(ConflictError);
+        });
+
+        it('update round-trips through the hash returned by the previous update', async () => {
+            fs.writeFileSync(path.join(dir, 'a.yaml'), VALID_YAML);
+            await makeRegistry([], true, dir).start();
+            const config = registry.list()[0];
+            const v2 = await registry.update(config.id, VALID_YAML.replace('my-config', 'v2'), config.content_hash);
+            const v3 = await registry.update(v2.id, VALID_YAML.replace('my-config', 'v3'), v2.content_hash);
+            expect(v3.name).toBe('v3');
+        });
+
+        it('deletes the file and the registry entry', async () => {
+            fs.writeFileSync(path.join(dir, 'a.yaml'), VALID_YAML);
+            await makeRegistry([], true, dir).start();
+            const config = registry.list()[0];
+            await registry.delete(config.id);
+            expect(fs.existsSync(config.path)).toBe(false);
+            expect(registry.list()).toHaveLength(0);
+        });
+    });
+});
+
+describe('hashContent', () => {
+    it('is deterministic and content-sensitive', () => {
+        expect(hashContent('abc')).toBe(hashContent('abc'));
+        expect(hashContent('abc')).not.toBe(hashContent('abd'));
+    });
+});

--- a/tests/controller-runner.test.ts
+++ b/tests/controller-runner.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { JobRunner } from '../controller/job-runner';
+import { ConflictError, ConfigRecord, LogRow, RunRecord } from '../controller/types';
+
+function makeLogger(): any {
+    const l: any = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), section: vi.fn(), event: vi.fn() };
+    l.child = vi.fn(() => makeLogger());
+    return l;
+}
+
+function makeConfig(id: number, overrides: Partial<ConfigRecord> = {}): ConfigRecord {
+    return {
+        id,
+        path: `/x/config-${id}.yaml`,
+        name: `config-${id}`,
+        content: '',
+        content_hash: `hash-${id}`,
+        schedule: null,
+        source_summary: [],
+        parse_error: null,
+        enabled: true,
+        deleted_at: null,
+        created_at: '',
+        updated_at: '',
+        ...overrides,
+    };
+}
+
+/** Minimal in-memory stand-in for ControllerStore. */
+function makeStore() {
+    let nextRunId = 1;
+    const runs = new Map<number, RunRecord>();
+    const logs = new Map<number, LogRow[]>();
+    return {
+        runs,
+        logs,
+        createRun: vi.fn(async (configId: number, configHash: string, trigger: any, status: any, error?: string) => {
+            const run: RunRecord = {
+                id: nextRunId++,
+                config_id: configId,
+                config_hash: configHash,
+                trigger,
+                status,
+                pid: null,
+                exit_code: null,
+                error: error ?? null,
+                stats: {},
+                queued_at: new Date().toISOString(),
+                started_at: null,
+                finished_at: status === 'skipped' ? new Date().toISOString() : null,
+            };
+            runs.set(run.id, run);
+            return run;
+        }),
+        // Like the real store, return fresh row objects instead of mutating shared ones
+        markRunStarted: vi.fn(async (runId: number, pid: number) => {
+            const run = { ...runs.get(runId)!, status: 'running' as const, pid, started_at: new Date().toISOString() };
+            runs.set(runId, run);
+            return run;
+        }),
+        finishRun: vi.fn(async (runId: number, outcome: any) => {
+            const run = {
+                ...runs.get(runId)!,
+                status: outcome.status,
+                exit_code: outcome.exitCode ?? null,
+                error: outcome.error ?? null,
+                stats: outcome.stats ?? {},
+                finished_at: new Date().toISOString(),
+            };
+            runs.set(runId, run);
+            return run;
+        }),
+        getRun: vi.fn(async (runId: number) => runs.get(runId) ?? null),
+        insertLogs: vi.fn(async (runId: number, rows: LogRow[]) => {
+            logs.set(runId, [...(logs.get(runId) ?? []), ...rows]);
+        }),
+    };
+}
+
+function makeEvents(): any {
+    return { emitRunUpdate: vi.fn(), emitRunLogs: vi.fn(), emitConfigUpdate: vi.fn() };
+}
+
+/** Waits until the run reaches a terminal status or the timeout hits. */
+async function waitForRun(store: any, runId: number, timeoutMs = 10_000): Promise<RunRecord> {
+    const terminal = ['succeeded', 'failed', 'canceled', 'skipped'];
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const run = store.runs.get(runId);
+        if (run && terminal.includes(run.status)) return run;
+        await new Promise(resolve => setTimeout(resolve, 50));
+    }
+    throw new Error(`run ${runId} did not finish in time (status: ${store.runs.get(runId)?.status})`);
+}
+
+/** commandFor stub: runs an inline node script instead of a real sync. */
+function inlineScript(script: string) {
+    return () => ({ cmd: process.execPath, args: ['-e', script] });
+}
+
+describe('JobRunner', () => {
+    let store: ReturnType<typeof makeStore>;
+    let events: any;
+
+    beforeEach(() => {
+        store = makeStore();
+        events = makeEvents();
+    });
+
+    function makeRunner(script: string, maxParallel = 1) {
+        return new JobRunner(store as any, events, { maxParallel, commandFor: inlineScript(script) }, makeLogger());
+    }
+
+    it('runs a job to success and captures structured logs + run-summary stats', async () => {
+        const runner = makeRunner(`
+            console.log(JSON.stringify({ ts: new Date().toISOString(), level: 'info', module: 'test', msg: 'hello' }));
+            console.log(JSON.stringify({ event: 'run-summary', sources: [{ product_name: 'p', type: 'website', version: '1', duration_ms: 5, ok: true }] }));
+        `);
+        const run = await runner.enqueue(makeConfig(1), 'manual');
+        expect(run.status).toBe('queued');
+
+        const finished = await waitForRun(store, run.id);
+        expect(finished.status).toBe('succeeded');
+        expect(finished.exit_code).toBe(0);
+        expect(finished.stats.sources).toHaveLength(1);
+
+        const logs = store.logs.get(run.id) ?? [];
+        expect(logs.some(l => l.message === 'hello' && l.level === 'info' && l.module === 'test')).toBe(true);
+        // run-summary is stats, not a log line
+        expect(logs.some(l => l.message.includes('run-summary'))).toBe(false);
+    });
+
+    it('marks non-zero exits as failed and names failing sources', async () => {
+        const runner = makeRunner(`
+            console.log(JSON.stringify({ event: 'run-summary', sources: [{ product_name: 'bad-src', type: 'website', version: '1', duration_ms: 5, ok: false, error: 'boom' }] }));
+            process.exit(1);
+        `);
+        const run = await runner.enqueue(makeConfig(1), 'manual');
+        const finished = await waitForRun(store, run.id);
+        expect(finished.status).toBe('failed');
+        expect(finished.exit_code).toBe(1);
+        expect(finished.error).toContain('bad-src');
+    });
+
+    it('stores non-JSON output as plain log lines', async () => {
+        const runner = makeRunner(`
+            console.log('plain stdout noise');
+            console.error('plain stderr noise');
+        `);
+        const run = await runner.enqueue(makeConfig(1), 'manual');
+        await waitForRun(store, run.id);
+        const logs = store.logs.get(run.id) ?? [];
+        expect(logs.find(l => l.message === 'plain stdout noise')?.level).toBe('info');
+        expect(logs.find(l => l.message === 'plain stderr noise')?.level).toBe('warn');
+    });
+
+    it('rejects a manual run while the config is busy, and skips an overlapping scheduled run', async () => {
+        const runner = makeRunner(`setTimeout(() => {}, 2000);`);
+        const config = makeConfig(1);
+        const first = await runner.enqueue(config, 'manual');
+
+        await expect(runner.enqueue(config, 'manual')).rejects.toThrow(ConflictError);
+
+        const skipped = await runner.enqueue(config, 'scheduled');
+        expect(skipped.status).toBe('skipped');
+
+        await runner.cancel(first.id);
+        await waitForRun(store, first.id);
+    });
+
+    it('honors maxParallel with a FIFO queue across different configs', async () => {
+        const runner = makeRunner(`setTimeout(() => {}, 300);`, 1);
+        const run1 = await runner.enqueue(makeConfig(1), 'manual');
+        const run2 = await runner.enqueue(makeConfig(2), 'manual');
+
+        // Only one may be running at a time
+        await new Promise(resolve => setTimeout(resolve, 100));
+        expect(store.runs.get(run1.id)!.status).toBe('running');
+        expect(store.runs.get(run2.id)!.status).toBe('queued');
+
+        await waitForRun(store, run1.id);
+        const second = await waitForRun(store, run2.id);
+        expect(second.status).toBe('succeeded');
+    });
+
+    it('cancel terminates a running job and marks it canceled', async () => {
+        const runner = makeRunner(`setTimeout(() => {}, 30000);`);
+        const run = await runner.enqueue(makeConfig(1), 'manual');
+        await new Promise(resolve => setTimeout(resolve, 200));
+
+        await runner.cancel(run.id);
+        const finished = await waitForRun(store, run.id);
+        expect(finished.status).toBe('canceled');
+    });
+
+    it('cancel removes a queued job without spawning it', async () => {
+        const runner = makeRunner(`setTimeout(() => {}, 2000);`, 1);
+        const running = await runner.enqueue(makeConfig(1), 'manual');
+        const queued = await runner.enqueue(makeConfig(2), 'manual');
+
+        const canceled = await runner.cancel(queued.id);
+        expect(canceled.status).toBe('canceled');
+
+        await runner.cancel(running.id);
+        await waitForRun(store, running.id);
+    });
+
+    it('shutdown cancels queued runs and fails running ones', async () => {
+        const runner = makeRunner(`setTimeout(() => {}, 30000);`, 1);
+        const running = await runner.enqueue(makeConfig(1), 'manual');
+        const queued = await runner.enqueue(makeConfig(2), 'manual');
+        await new Promise(resolve => setTimeout(resolve, 200));
+
+        await runner.shutdown();
+
+        expect(store.runs.get(queued.id)!.status).toBe('canceled');
+        const finishedRunning = store.runs.get(running.id)!;
+        expect(finishedRunning.status).toBe('failed');
+        expect(finishedRunning.error).toBe('controller shutdown');
+
+        await expect(runner.enqueue(makeConfig(3), 'manual')).rejects.toThrow(ConflictError);
+    });
+
+    it('rejects runs for configs with parse errors', async () => {
+        const runner = makeRunner('');
+        await expect(runner.enqueue(makeConfig(1, { parse_error: 'bad yaml' }), 'manual')).rejects.toThrow(/invalid/);
+    });
+});

--- a/tests/controller-scheduler.test.ts
+++ b/tests/controller-scheduler.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { Scheduler } from '../controller/scheduler';
+import { ConfigRecord } from '../controller/types';
+
+function makeLogger(): any {
+    const l: any = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), section: vi.fn(), event: vi.fn() };
+    l.child = vi.fn(() => makeLogger());
+    return l;
+}
+
+function makeConfig(overrides: Partial<ConfigRecord> = {}): ConfigRecord {
+    return {
+        id: 1,
+        path: '/x/a.yaml',
+        name: 'a',
+        content: '',
+        content_hash: 'h1',
+        schedule: '0 2 * * *',
+        source_summary: [],
+        parse_error: null,
+        enabled: true,
+        deleted_at: null,
+        created_at: '',
+        updated_at: '',
+        ...overrides,
+    };
+}
+
+describe('Scheduler', () => {
+    let scheduler: Scheduler;
+
+    afterEach(() => scheduler?.stop());
+
+    it('schedules configs with a valid cron and reports nextRun', () => {
+        scheduler = new Scheduler(() => {}, makeLogger());
+        scheduler.sync([makeConfig()]);
+        const next = scheduler.nextRun(1);
+        expect(next).toBeTruthy();
+        const nextDate = new Date(next!);
+        expect(nextDate.getHours()).toBe(2);
+        expect(nextDate.getMinutes()).toBe(0);
+    });
+
+    it('does not schedule configs without a schedule, with parse errors, or deleted', () => {
+        scheduler = new Scheduler(() => {}, makeLogger());
+        scheduler.sync([
+            makeConfig({ id: 1, schedule: null }),
+            makeConfig({ id: 2, parse_error: 'broken' }),
+            makeConfig({ id: 3, deleted_at: new Date().toISOString() }),
+            makeConfig({ id: 4, enabled: false }),
+        ]);
+        for (const id of [1, 2, 3, 4]) expect(scheduler.nextRun(id)).toBeNull();
+    });
+
+    it('reschedules when the cron pattern changes and keeps it otherwise', () => {
+        scheduler = new Scheduler(() => {}, makeLogger());
+        scheduler.sync([makeConfig()]);
+        const before = scheduler.nextRun(1);
+
+        scheduler.sync([makeConfig()]); // same pattern → same cron kept
+        expect(scheduler.nextRun(1)).toBe(before);
+
+        scheduler.sync([makeConfig({ schedule: '0 5 * * *' })]);
+        expect(new Date(scheduler.nextRun(1)!).getHours()).toBe(5);
+    });
+
+    it('unschedules configs that disappear from the list', () => {
+        scheduler = new Scheduler(() => {}, makeLogger());
+        scheduler.sync([makeConfig()]);
+        expect(scheduler.nextRun(1)).toBeTruthy();
+        scheduler.sync([]);
+        expect(scheduler.nextRun(1)).toBeNull();
+    });
+
+    it('fires the trigger callback when the schedule elapses', async () => {
+        const fired: number[] = [];
+        scheduler = new Scheduler(id => fired.push(id), makeLogger());
+        // croner supports second-granularity patterns
+        scheduler.sync([makeConfig({ schedule: '* * * * * *' })]);
+        await new Promise(resolve => setTimeout(resolve, 1500));
+        expect(fired.length).toBeGreaterThanOrEqual(1);
+        expect(fired[0]).toBe(1);
+    });
+});

--- a/tests/controller-store.test.ts
+++ b/tests/controller-store.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { ControllerStore } from '../controller/store';
+
+// These tests need a real Postgres. Run them with e.g.:
+//   TEST_DATABASE_URL=postgres://postgres:test@localhost:5433/doc2vec npm test
+const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL;
+
+function makeLogger(): any {
+    const l: any = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), section: vi.fn(), event: vi.fn() };
+    l.child = vi.fn(() => makeLogger());
+    return l;
+}
+
+describe.skipIf(!TEST_DATABASE_URL)('ControllerStore (Postgres)', () => {
+    let store: ControllerStore;
+
+    beforeAll(async () => {
+        store = new ControllerStore(TEST_DATABASE_URL!, makeLogger());
+        await store.init();
+    });
+
+    afterAll(async () => {
+        await store?.close();
+    });
+
+    it('applies migrations idempotently', async () => {
+        const again = new ControllerStore(TEST_DATABASE_URL!, makeLogger());
+        await again.init();
+        await again.close();
+    });
+
+    it('upserts configs by path and round-trips fields', async () => {
+        const created = await store.upsertConfig({
+            path: '/test/store-a.yaml',
+            name: 'store-a',
+            content: 'sources: []',
+            contentHash: 'h1',
+            schedule: '0 2 * * *',
+            sourceSummary: [{ type: 'website', product_name: 'p' }],
+            parseError: null,
+        });
+        expect(created.id).toBeGreaterThan(0);
+        expect(created.schedule).toBe('0 2 * * *');
+        expect(created.source_summary).toEqual([{ type: 'website', product_name: 'p' }]);
+
+        const updated = await store.upsertConfig({
+            path: '/test/store-a.yaml',
+            name: 'store-a2',
+            content: 'sources: [] # v2',
+            contentHash: 'h2',
+            schedule: null,
+            sourceSummary: [],
+            parseError: 'oops',
+        });
+        expect(updated.id).toBe(created.id);
+        expect(updated.name).toBe('store-a2');
+        expect(updated.parse_error).toBe('oops');
+    });
+
+    it('soft-deletes and revives configs', async () => {
+        const config = await store.upsertConfig({
+            path: '/test/store-b.yaml', name: 'store-b', content: 'x', contentHash: 'h',
+            schedule: null, sourceSummary: [], parseError: null,
+        });
+        await store.markConfigDeleted(config.path);
+        expect((await store.listConfigs()).find(c => c.id === config.id)).toBeUndefined();
+        expect((await store.listConfigs(true)).find(c => c.id === config.id)).toBeDefined();
+
+        // Re-upserting the same path revives it
+        await store.upsertConfig({
+            path: '/test/store-b.yaml', name: 'store-b', content: 'x', contentHash: 'h',
+            schedule: null, sourceSummary: [], parseError: null,
+        });
+        expect((await store.listConfigs()).find(c => c.id === config.id)).toBeDefined();
+    });
+
+    it('covers the run lifecycle and log paging', async () => {
+        const config = await store.upsertConfig({
+            path: '/test/store-c.yaml', name: 'store-c', content: 'x', contentHash: 'h',
+            schedule: null, sourceSummary: [], parseError: null,
+        });
+
+        const run = await store.createRun(config.id, 'h', 'manual', 'queued');
+        expect(run.status).toBe('queued');
+
+        const started = await store.markRunStarted(run.id, 12345);
+        expect(started.status).toBe('running');
+        expect(started.pid).toBe(12345);
+
+        await store.insertLogs(run.id, [
+            { seq: 1, ts: new Date().toISOString(), level: 'info', module: 'm', message: 'one' },
+            { seq: 2, ts: new Date().toISOString(), level: 'warn', module: null, message: 'two' },
+            { seq: 3, ts: new Date().toISOString(), level: 'error', module: 'm', message: 'three' },
+        ]);
+        // Duplicate seq inserts are ignored (flush retry safety)
+        await store.insertLogs(run.id, [
+            { seq: 3, ts: new Date().toISOString(), level: 'error', module: 'm', message: 'dupe' },
+        ]);
+
+        const page1 = await store.getLogs(run.id, 0, 2);
+        expect(page1.map(l => l.seq)).toEqual([1, 2]);
+        const page2 = await store.getLogs(run.id, 2, 10);
+        expect(page2.map(l => l.seq)).toEqual([3]);
+        expect(page2[0].message).toBe('three');
+
+        const finished = await store.finishRun(run.id, {
+            status: 'succeeded',
+            exitCode: 0,
+            stats: { sources: [{ product_name: 'p', type: 'website', version: '1', duration_ms: 10, ok: true }], warn_count: 1, error_count: 1 },
+        });
+        expect(finished.status).toBe('succeeded');
+        expect(finished.stats.warn_count).toBe(1);
+
+        const runs = await store.listRuns({ configId: config.id });
+        expect(runs[0].id).toBe(run.id);
+
+        const lastRuns = await store.getLastRuns();
+        expect(lastRuns.get(config.id)?.id).toBe(run.id);
+
+        const stats = await store.getConfigStats(config.id, 30);
+        expect(stats.totals.total).toBeGreaterThanOrEqual(1);
+        expect(stats.totals.succeeded).toBeGreaterThanOrEqual(1);
+    });
+
+    it('marks orphaned runs failed on init', async () => {
+        const config = await store.upsertConfig({
+            path: '/test/store-d.yaml', name: 'store-d', content: 'x', contentHash: 'h',
+            schedule: null, sourceSummary: [], parseError: null,
+        });
+        const orphan = await store.createRun(config.id, 'h', 'scheduled', 'queued');
+        await store.markRunStarted(orphan.id, 999);
+
+        const second = new ControllerStore(TEST_DATABASE_URL!, makeLogger());
+        await second.init();
+        const after = await second.getRun(orphan.id);
+        await second.close();
+
+        expect(after?.status).toBe('failed');
+        expect(after?.error).toMatch(/controller restarted/);
+    });
+});

--- a/tests/doc2vec.test.ts
+++ b/tests/doc2vec.test.ts
@@ -118,6 +118,7 @@ vi.mock('../logger', () => {
             error: vi.fn(),
             debug: vi.fn(),
             section: vi.fn(),
+            event: vi.fn(),
             progress: vi.fn().mockReturnValue({
                 update: vi.fn(),
                 complete: vi.fn(),
@@ -755,7 +756,7 @@ sources:
             function makeLogger(): any {
                 const l: any = {
                     info: vi.fn(), warn: vi.fn(), error: vi.fn(),
-                    debug: vi.fn(), section: vi.fn(),
+                    debug: vi.fn(), section: vi.fn(), event: vi.fn(),
                 };
                 l.child = vi.fn(() => makeLogger());
                 return l;
@@ -1403,7 +1404,7 @@ sources:
             const instance = new Doc2Vec(configPath);
 
             // run() should complete without errors on empty sources
-            await expect(instance.run()).resolves.toBeUndefined();
+            await expect(instance.run()).resolves.toEqual([]);
         });
 
         it('should handle config with only code sources', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
       "moduleResolution": "node"
     },
     "include": ["**/*.ts"],
-    "exclude": ["node_modules", "mcp", "tests"]
+    "exclude": ["node_modules", "mcp", "tests", "ui"]
   }

--- a/types.ts
+++ b/types.ts
@@ -123,6 +123,8 @@ export interface MarkdownStoreConfig {
 }
 
 export interface Config {
+    name?: string;                // Optional display name (used by controller mode; defaults to file basename)
+    schedule?: string;            // Optional cron expression — controller mode runs this config on the schedule; ignored in one-shot mode
     sources: SourceConfig[];
     embedding?: EmbeddingConfig;  // Optional, defaults to OpenAI
     markdown_store?: MarkdownStoreConfig;  // Optional Postgres markdown store
@@ -148,6 +150,17 @@ export interface DocumentChunk {
 export interface BrokenLink {
     source: string;
     target: string;
+}
+
+// Per-source outcome of a sync run, emitted as the `run-summary` structured event
+// and consumed by the controller to build run statistics
+export interface SourceRunStats {
+    product_name: string;
+    type: string;
+    version: string;
+    duration_ms: number;
+    ok: boolean;
+    error?: string;
 }
 
 export interface SqliteDB {

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>doc2vec</title>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='0.9em' font-size='90'%3E%F0%9F%93%9A%3C/text%3E%3C/svg%3E" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,0 +1,3205 @@
+{
+  "name": "doc2vec-ui",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "doc2vec-ui",
+      "version": "0.0.0",
+      "dependencies": {
+        "@codemirror/lang-yaml": "^6.1.2",
+        "@tanstack/react-query": "^5.90.0",
+        "@uiw/react-codemirror": "^4.25.4",
+        "cronstrue": "^3.9.0",
+        "js-yaml": "^5.2.1",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+        "react-router-dom": "^7.9.0",
+        "recharts": "^3.7.0"
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.1.0",
+        "@types/js-yaml": "^4.0.9",
+        "@types/react": "^19.2.0",
+        "@types/react-dom": "^19.2.0",
+        "@vitejs/plugin-react": "^5.1.0",
+        "tailwindcss": "^4.1.0",
+        "typescript": "^5.9.0",
+        "vite": "^7.3.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+      "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-yaml": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
+      "integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.0.0",
+        "@lezer/yaml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.1.tgz",
+      "integrity": "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz",
+      "integrity": "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/yaml": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "license": "MIT"
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
+      "integrity": "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "5.21.6",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
+      "integrity": "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.2",
+        "@tailwindcss/oxide-darwin-x64": "4.3.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.2.tgz",
+      "integrity": "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.2.tgz",
+      "integrity": "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.2.tgz",
+      "integrity": "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.2.tgz",
+      "integrity": "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.2.tgz",
+      "integrity": "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.2.tgz",
+      "integrity": "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.2.tgz",
+      "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.2.tgz",
+      "integrity": "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.2.tgz",
+      "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.2.tgz",
+      "integrity": "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
+      "integrity": "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.2.tgz",
+      "integrity": "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.2.tgz",
+      "integrity": "sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.2",
+        "@tailwindcss/oxide": "4.3.2",
+        "tailwindcss": "4.3.2"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
+      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
+      "integrity": "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@uiw/codemirror-extensions-basic-setup": {
+      "version": "4.25.10",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.10.tgz",
+      "integrity": "sha512-P3vytLlpE62KYSWrMUnwDCv2lvaQDuDZzyj03mHntuHo5bSl34fRZpjTY3kQTPGuXHxkGSYpoPFFj+hMTqaaMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": ">=6.0.0",
+        "@codemirror/commands": ">=6.0.0",
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/lint": ">=6.0.0",
+        "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/react-codemirror": {
+      "version": "4.25.10",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.10.tgz",
+      "integrity": "sha512-DzgSMwM5qzB7v1FIb4gEeriYt67iiay756/HIOM9mAbeOVK0MO7rqefHf0O5c0269pJKMW7AH9FjclExD23V9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@codemirror/commands": "^6.1.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "@uiw/codemirror-extensions-basic-setup": "4.25.10",
+        "codemirror": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/theme-one-dark": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0",
+        "codemirror": ">=6.0.0",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.42",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
+      "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001800",
+        "electron-to-chromium": "^1.5.387",
+        "node-releases": "^2.0.50",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001803",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "license": "MIT"
+    },
+    "node_modules/cronstrue": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-3.24.0.tgz",
+      "integrity": "sha512-t/Ji3Ur2c/pzhIAWNwC0ftl3JAE4dLfCjAdZoTZXmPDZwcispnS1PaMcMS4OmIIXyIVouAz+yw+mfQiE3hz5OQ==",
+      "license": "MIT",
+      "bin": {
+        "cronstrue": "bin/cli.js"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.388",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.388.tgz",
+      "integrity": "sha512-Pl/aJaqOOxYxda3vcx1IKSJimwYXHDkEnGn0F+kG2EE68dDtx2uCinaS+Vih8Z91B9t8CSAbiF/HKyWcnXjhzw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
+      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/immer": {
+      "version": "11.1.11",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.11.tgz",
+      "integrity": "sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.2.tgz",
+      "integrity": "sha512-G4fy+Pk46RaXgwWMh+Nzhyo/lbFAVqXo9gtetlyehe6Ehge9CsgDuOTwQDD+i1+llaLktNBiNq4bhnGlDRXFtw==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^11.1.8",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
+      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "doc2vec-ui",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@codemirror/lang-yaml": "^6.1.2",
+    "@tanstack/react-query": "^5.90.0",
+    "@uiw/react-codemirror": "^4.25.4",
+    "cronstrue": "^3.9.0",
+    "js-yaml": "^5.2.1",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "react-router-dom": "^7.9.0",
+    "recharts": "^3.7.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.1.0",
+    "@types/js-yaml": "^4.0.9",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "@vitejs/plugin-react": "^5.1.0",
+    "tailwindcss": "^4.1.0",
+    "typescript": "^5.9.0",
+    "vite": "^7.3.0"
+  }
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,0 +1,57 @@
+import { useEffect } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Link, Route, Routes } from 'react-router-dom';
+import { api } from './api';
+import Dashboard from './pages/Dashboard';
+import ConfigDetail from './pages/ConfigDetail';
+import RunDetail from './pages/RunDetail';
+
+export default function App() {
+  const queryClient = useQueryClient();
+  const { data: health } = useQuery({ queryKey: ['health'], queryFn: api.health });
+
+  // Global event stream: any run/config change refreshes the relevant queries
+  useEffect(() => {
+    const source = new EventSource('/api/events');
+    const invalidate = () => {
+      queryClient.invalidateQueries({ queryKey: ['configs'] });
+      queryClient.invalidateQueries({ queryKey: ['runs'] });
+    };
+    source.addEventListener('run:update', invalidate);
+    source.addEventListener('config:update', invalidate);
+    return () => source.close();
+  }, [queryClient]);
+
+  return (
+    <div className="min-h-screen">
+      <header className="border-b border-edge bg-surface">
+        <div className="mx-auto flex max-w-6xl items-center gap-3 px-6 py-4">
+          <Link to="/" className="flex items-center gap-2 text-lg font-semibold tracking-tight">
+            <span aria-hidden>📚</span> doc2vec
+          </Link>
+          <span className="text-sm text-ink-muted">controller</span>
+          <div className="ml-auto flex items-center gap-3 text-sm">
+            {health && (
+              <>
+                <span
+                  className="rounded-full border border-edge px-2.5 py-0.5 text-xs font-medium text-ink-secondary"
+                  title={health.mode === 'rw' ? 'Configs can be created and edited from this UI' : 'Configs are managed from files only'}
+                >
+                  {health.mode === 'rw' ? 'read-write' : 'read-only'}
+                </span>
+                <span className="text-ink-muted">v{health.version}</span>
+              </>
+            )}
+          </div>
+        </div>
+      </header>
+      <main className="mx-auto max-w-6xl px-6 py-8">
+        <Routes>
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/configs/:id" element={<ConfigDetail />} />
+          <Route path="/runs/:id" element={<RunDetail />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,0 +1,127 @@
+// API client + shared types (mirrors controller/types.ts)
+
+export interface SourceSummary {
+  type: string;
+  product_name: string;
+  version?: string;
+}
+
+export type RunStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'skipped' | 'canceled';
+
+export interface RunRecord {
+  id: number;
+  config_id: number;
+  config_hash: string;
+  trigger: 'scheduled' | 'manual';
+  status: RunStatus;
+  pid: number | null;
+  exit_code: number | null;
+  error: string | null;
+  stats: {
+    sources?: Array<{
+      product_name: string;
+      type: string;
+      version: string;
+      duration_ms: number;
+      ok: boolean;
+      error?: string;
+    }>;
+    warn_count?: number;
+    error_count?: number;
+  };
+  queued_at: string;
+  started_at: string | null;
+  finished_at: string | null;
+  config_name?: string | null;
+}
+
+export interface ConfigRecord {
+  id: number;
+  path: string;
+  name: string;
+  content: string;
+  content_hash: string;
+  schedule: string | null;
+  source_summary: SourceSummary[];
+  parse_error: string | null;
+  enabled: boolean;
+  next_run: string | null;
+  last_run: RunRecord | null;
+  busy: boolean;
+}
+
+export interface LogRow {
+  seq: number;
+  ts: string;
+  level: string;
+  module: string | null;
+  message: string;
+}
+
+export interface ConfigStats {
+  daily: Array<{ day: string; status: string; count: number; avg_duration_s: number | null }>;
+  recentDurations: Array<{ id: number; status: string; started_at: string; duration_s: number }>;
+  totals: { total: number; succeeded: number; failed: number; skipped: number; canceled: number };
+}
+
+export interface Health {
+  status: string;
+  mode: 'ro' | 'rw';
+  version: string;
+}
+
+export class ApiError extends Error {
+  constructor(public status: number, message: string) {
+    super(message);
+  }
+}
+
+async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+  if (!res.ok) {
+    let message = res.statusText;
+    try {
+      const body = await res.json();
+      if (body?.error) message = body.error;
+    } catch {
+      /* non-JSON error body */
+    }
+    throw new ApiError(res.status, message);
+  }
+  if (res.status === 204) return undefined as T;
+  return res.json();
+}
+
+export const api = {
+  health: () => request<Health>('/api/health'),
+  configs: () => request<ConfigRecord[]>('/api/configs'),
+  config: (id: number) => request<ConfigRecord>(`/api/configs/${id}`),
+  createConfig: (filename: string, content: string) =>
+    request<ConfigRecord>('/api/configs', { method: 'POST', body: JSON.stringify({ filename, content }) }),
+  updateConfig: (id: number, content: string, baseHash: string) =>
+    request<ConfigRecord>(`/api/configs/${id}`, { method: 'PUT', body: JSON.stringify({ content, baseHash }) }),
+  deleteConfig: (id: number) => request<void>(`/api/configs/${id}`, { method: 'DELETE' }),
+  validateConfig: (content: string) =>
+    request<{ valid: boolean; error: string | null; name: string; schedule: string | null; sources: SourceSummary[] }>(
+      '/api/configs/validate',
+      { method: 'POST', body: JSON.stringify({ content }) }
+    ),
+  triggerRun: (configId: number) => request<RunRecord>(`/api/configs/${configId}/run`, { method: 'POST' }),
+  configStats: (configId: number, days: number) =>
+    request<ConfigStats>(`/api/configs/${configId}/stats?days=${days}`),
+  runs: (params: { configId?: number; status?: string; limit?: number; before?: number } = {}) => {
+    const qs = new URLSearchParams();
+    if (params.configId !== undefined) qs.set('configId', String(params.configId));
+    if (params.status !== undefined) qs.set('status', params.status);
+    if (params.limit !== undefined) qs.set('limit', String(params.limit));
+    if (params.before !== undefined) qs.set('before', String(params.before));
+    return request<RunRecord[]>(`/api/runs?${qs}`);
+  },
+  run: (id: number) => request<RunRecord>(`/api/runs/${id}`),
+  runLogs: (id: number, afterSeq = 0, limit = 1000) =>
+    request<LogRow[]>(`/api/runs/${id}/logs?afterSeq=${afterSeq}&limit=${limit}`),
+  cancelRun: (id: number) => request<RunRecord>(`/api/runs/${id}/cancel`, { method: 'POST' }),
+};

--- a/ui/src/components/ConfigEditor.tsx
+++ b/ui/src/components/ConfigEditor.tsx
@@ -1,0 +1,104 @@
+import { useMemo, useState } from 'react';
+import CodeMirror from '@uiw/react-codemirror';
+import { yaml } from '@codemirror/lang-yaml';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { api, ApiError, ConfigRecord } from '../api';
+
+type Props =
+  | { mode: 'view'; config: ConfigRecord }
+  | { mode: 'edit'; config: ConfigRecord; onSaved?: (record: ConfigRecord) => void }
+  | { mode: 'create'; initialContent: string; onSaved?: (record: ConfigRecord) => void; onCancel?: () => void };
+
+export default function ConfigEditor(props: Props) {
+  const queryClient = useQueryClient();
+  const initial = props.mode === 'create' ? props.initialContent : props.config.content;
+  const [content, setContent] = useState(initial);
+  const [filename, setFilename] = useState('new-config.yaml');
+  const [validation, setValidation] = useState<string | null>(null);
+
+  const dirty = content !== initial;
+  const dark = useMemo(() => window.matchMedia('(prefers-color-scheme: dark)').matches, []);
+
+  const save = useMutation({
+    mutationFn: async () => {
+      const check = await api.validateConfig(content);
+      if (!check.valid) {
+        throw new ApiError(400, check.error ?? 'invalid config');
+      }
+      if (props.mode === 'create') {
+        return api.createConfig(filename, content);
+      }
+      if (props.mode === 'edit') {
+        return api.updateConfig(props.config.id, content, props.config.content_hash);
+      }
+      throw new Error('unreachable');
+    },
+    onSuccess: record => {
+      setValidation(null);
+      queryClient.invalidateQueries({ queryKey: ['configs'] });
+      if (props.mode !== 'view') props.onSaved?.(record);
+    },
+    onError: err => setValidation((err as ApiError).message),
+  });
+
+  const conflict = save.error instanceof ApiError && save.error.status === 409;
+  const readOnly = props.mode === 'view';
+
+  return (
+    <div className="space-y-3">
+      {props.mode === 'create' && (
+        <label className="block text-sm">
+          <span className="mb-1 block text-xs uppercase tracking-wide text-ink-muted">Filename</span>
+          <input
+            value={filename}
+            onChange={e => setFilename(e.target.value)}
+            className="w-72 rounded-md border border-edge bg-page px-3 py-1.5 font-mono text-sm outline-none focus:border-accent"
+            placeholder="my-config.yaml"
+          />
+        </label>
+      )}
+
+      {conflict && (
+        <div className="rounded-md border border-warning/50 bg-surface px-3 py-2 text-sm text-ink-secondary">
+          ⚠ The file changed on disk since you loaded it. Reload the page and reapply your edits.
+        </div>
+      )}
+      {validation && !conflict && (
+        <div className="rounded-md border border-critical/50 bg-surface px-3 py-2 text-sm text-critical">{validation}</div>
+      )}
+
+      <div className="overflow-hidden rounded-md border border-edge">
+        <CodeMirror
+          value={content}
+          onChange={setContent}
+          extensions={[yaml()]}
+          editable={!readOnly}
+          theme={dark ? 'dark' : 'light'}
+          minHeight="240px"
+          maxHeight="560px"
+        />
+      </div>
+
+      {!readOnly && (
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => save.mutate()}
+            disabled={save.isPending || (props.mode === 'edit' && !dirty)}
+            className="rounded-md bg-accent px-3.5 py-1.5 text-sm font-medium text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {save.isPending ? 'Saving…' : props.mode === 'create' ? 'Create config' : 'Save changes'}
+          </button>
+          {props.mode === 'create' && (
+            <button onClick={() => props.onCancel?.()} className="text-sm text-ink-muted hover:text-ink-secondary">
+              Cancel
+            </button>
+          )}
+          {props.mode === 'edit' && dirty && <span className="text-xs text-ink-muted">unsaved changes</span>}
+          <span className="ml-auto text-xs text-ink-muted">
+            Secrets stay as <code>{'${ENV_VAR}'}</code> placeholders — they are resolved only inside sync jobs.
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/ConfigForm.tsx
+++ b/ui/src/components/ConfigForm.tsx
@@ -1,0 +1,453 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import * as yaml from 'js-yaml';
+import { api, ApiError, ConfigRecord } from '../api';
+import {
+  BASE_SOURCE_FIELDS,
+  DATABASE_TYPES,
+  EMBEDDING_PROVIDERS,
+  FieldDef,
+  MARKDOWN_STORE_FIELDS,
+  SOURCE_TYPES,
+  newSource,
+} from '../lib/config-schema';
+import { humanizeCron } from '../lib/format';
+
+type Path = Array<string | number>;
+
+function getPath(obj: any, path: Path): any {
+  return path.reduce((acc, key) => (acc == null ? undefined : acc[key]), obj);
+}
+
+/** Immutable deep-set; empty-ish values delete the key so the YAML stays clean. */
+function setPath(obj: any, path: Path, value: any): any {
+  if (path.length === 0) return value;
+  const [head, ...rest] = path;
+  const clone: any = Array.isArray(obj) ? [...(obj ?? [])] : { ...(obj ?? {}) };
+  if (rest.length === 0) {
+    if (value === undefined || value === '' || (Array.isArray(value) && value.length === 0)) {
+      delete clone[head];
+    } else {
+      clone[head] = value;
+    }
+  } else {
+    clone[head] = setPath(clone[head], rest, value);
+  }
+  return clone;
+}
+
+const inputClass =
+  'w-full rounded-md border border-edge bg-page px-3 py-1.5 text-sm outline-none focus:border-accent placeholder:text-ink-muted/60';
+
+function FieldInput({ field, value, onChange }: { field: FieldDef; value: any; onChange: (v: any) => void }) {
+  // string_list keeps local text state so typing commas/spaces doesn't fight the parser
+  const [listText, setListText] = useState<string | null>(null);
+
+  if (field.type === 'boolean') {
+    return (
+      <label className="flex items-center gap-2 py-1.5 text-sm text-ink-secondary">
+        <input
+          type="checkbox"
+          checked={!!value}
+          onChange={e => onChange(e.target.checked || undefined)}
+          className="h-4 w-4 accent-(--accent)"
+        />
+        {field.label}
+        {field.help && <span className="text-xs text-ink-muted">— {field.help}</span>}
+      </label>
+    );
+  }
+
+  return (
+    <label className="block">
+      <span className="mb-1 flex items-baseline gap-2 text-xs font-medium text-ink-secondary">
+        {field.label}
+        {field.required && <span className="text-critical">*</span>}
+        {field.secret && (
+          <span className="text-ink-muted">
+            use a <code>{'${ENV_VAR}'}</code> placeholder
+          </span>
+        )}
+      </span>
+      {field.type === 'select' ? (
+        <select value={value ?? ''} onChange={e => onChange(e.target.value || undefined)} className={inputClass}>
+          <option value="">—</option>
+          {field.options!.map(opt => (
+            <option key={opt} value={opt}>{opt}</option>
+          ))}
+        </select>
+      ) : field.type === 'string_list' ? (
+        <input
+          value={listText ?? (Array.isArray(value) ? value.join(', ') : '')}
+          placeholder={field.placeholder}
+          onChange={e => setListText(e.target.value)}
+          onBlur={() => {
+            if (listText !== null) {
+              onChange(listText.split(',').map(s => s.trim()).filter(Boolean));
+              setListText(null);
+            }
+          }}
+          className={inputClass}
+        />
+      ) : (
+        <input
+          type="text"
+          inputMode={field.type === 'number' ? 'numeric' : undefined}
+          value={value ?? ''}
+          placeholder={field.placeholder}
+          onChange={e => {
+            const raw = e.target.value;
+            if (field.type === 'number') {
+              onChange(raw === '' ? undefined : Number(raw));
+            } else {
+              onChange(raw);
+            }
+          }}
+          className={inputClass}
+        />
+      )}
+      {field.help && <span className="mt-1 block text-xs text-ink-muted">{field.help}</span>}
+    </label>
+  );
+}
+
+function FieldGrid({ fields, doc, basePath, onSet }: {
+  fields: FieldDef[];
+  doc: any;
+  basePath: Path;
+  onSet: (path: Path, value: any) => void;
+}) {
+  return (
+    <div className="grid gap-x-4 gap-y-3 sm:grid-cols-2">
+      {fields.map(field => (
+        <div key={field.key} className={field.type === 'boolean' ? 'sm:col-span-2' : ''}>
+          <FieldInput
+            field={field}
+            value={getPath(doc, [...basePath, field.key])}
+            onChange={v => onSet([...basePath, field.key], v)}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SectionCard({ title, subtitle, action, children }: {
+  title: string;
+  subtitle?: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-lg border border-edge bg-surface p-4">
+      <div className="mb-3 flex items-center gap-2">
+        <h3 className="text-sm font-semibold">{title}</h3>
+        {subtitle && <span className="text-xs text-ink-muted">{subtitle}</span>}
+        <div className="ml-auto">{action}</div>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export default function ConfigForm(props: {
+  mode: 'create' | 'edit';
+  config?: ConfigRecord;             // required for edit
+  onSaved?: (record: ConfigRecord) => void;
+  onCancel?: () => void;
+}) {
+  const queryClient = useQueryClient();
+
+  const initial = useMemo(() => {
+    if (props.mode === 'edit' && props.config) {
+      try {
+        const parsed = yaml.load(props.config.content);
+        if (parsed && typeof parsed === 'object') return { doc: parsed as any, parseError: null };
+        return { doc: null, parseError: 'config is not a YAML mapping' };
+      } catch (err) {
+        return { doc: null, parseError: err instanceof Error ? err.message : String(err) };
+      }
+    }
+    return { doc: { name: '', schedule: '', sources: [newSource('website')] }, parseError: null };
+  }, [props.mode, props.config]);
+
+  const [doc, setDoc] = useState<any>(initial.doc);
+  const [filename, setFilename] = useState('');
+  const [apiErrorMessage, setApiErrorMessage] = useState<string | null>(null);
+
+  const save = useMutation({
+    mutationFn: async () => {
+      const content = yaml.dump(doc, { lineWidth: 120, noRefs: true });
+      const check = await api.validateConfig(content);
+      if (!check.valid) throw new ApiError(400, check.error ?? 'invalid config');
+      if (props.mode === 'create') {
+        const name = filename.trim() || `${(doc.name || 'config').toString().replace(/[^A-Za-z0-9._-]+/g, '-')}.yaml`;
+        return api.createConfig(name, content);
+      }
+      return api.updateConfig(props.config!.id, content, props.config!.content_hash);
+    },
+    onSuccess: record => {
+      setApiErrorMessage(null);
+      queryClient.invalidateQueries({ queryKey: ['configs'] });
+      props.onSaved?.(record);
+    },
+    onError: err => setApiErrorMessage((err as ApiError).message),
+  });
+
+  if (initial.parseError || !doc) {
+    return (
+      <p className="rounded-md border border-warning/50 bg-surface px-3 py-2 text-sm text-ink-secondary">
+        ⚠ This config can't be edited as a form ({initial.parseError}) — use the YAML view.
+      </p>
+    );
+  }
+
+  const set = (path: Path, value: any) => setDoc((prev: any) => setPath(prev, path, value));
+  const sources: any[] = Array.isArray(doc.sources) ? doc.sources : [];
+
+  const missingRequired: string[] = [];
+  sources.forEach((source, i) => {
+    const typeDef = SOURCE_TYPES[source?.type];
+    for (const field of [...BASE_SOURCE_FIELDS, ...(typeDef?.fields ?? [])]) {
+      if (!field.required) continue;
+      if (source?.type === 'code' && field.key === 'version') continue;
+      const value = source?.[field.key];
+      if (value === undefined || value === '') missingRequired.push(`source ${i + 1}: ${field.label}`);
+    }
+  });
+
+  const embeddingEnabled = doc.embedding !== undefined;
+  const markdownStoreEnabled = doc.markdown_store !== undefined;
+  const conflict = save.error instanceof ApiError && save.error.status === 409;
+  const scheduleValue = doc.schedule ?? '';
+
+  return (
+    <div className="space-y-4">
+      {conflict && (
+        <div className="rounded-md border border-warning/50 bg-surface px-3 py-2 text-sm text-ink-secondary">
+          ⚠ The file changed on disk since you loaded it. Reload the page and reapply your edits.
+        </div>
+      )}
+      {apiErrorMessage && !conflict && (
+        <div className="rounded-md border border-critical/50 bg-surface px-3 py-2 text-sm text-critical">{apiErrorMessage}</div>
+      )}
+
+      <SectionCard title="General">
+        <div className="grid gap-x-4 gap-y-3 sm:grid-cols-2">
+          {props.mode === 'create' && (
+            <label className="block">
+              <span className="mb-1 block text-xs font-medium text-ink-secondary">Filename</span>
+              <input
+                value={filename}
+                onChange={e => setFilename(e.target.value)}
+                placeholder={`${(doc.name || 'my-config').toString().replace(/[^A-Za-z0-9._-]+/g, '-')}.yaml`}
+                className={`${inputClass} font-mono`}
+              />
+            </label>
+          )}
+          <FieldInput
+            field={{ key: 'name', label: 'Display name', type: 'string', placeholder: 'product-docs' }}
+            value={doc.name}
+            onChange={v => set(['name'], v)}
+          />
+          <div>
+            <FieldInput
+              field={{ key: 'schedule', label: 'Schedule (cron)', type: 'string', placeholder: '0 2 * * *', help: 'Leave empty for manual runs only' }}
+              value={scheduleValue}
+              onChange={v => set(['schedule'], v)}
+            />
+            {scheduleValue && (
+              <p className="mt-1 text-xs text-accent">{humanizeCron(scheduleValue)}</p>
+            )}
+          </div>
+        </div>
+      </SectionCard>
+
+      {sources.map((source, i) => {
+        const typeDef = SOURCE_TYPES[source?.type] ?? SOURCE_TYPES.website;
+        const dbType = source?.database_config?.type ?? 'sqlite';
+        const dbDef = DATABASE_TYPES[dbType] ?? DATABASE_TYPES.sqlite;
+        return (
+          <SectionCard
+            key={i}
+            title={`Source ${i + 1}`}
+            subtitle={source?.product_name || undefined}
+            action={
+              <button
+                onClick={() => set(['sources'], sources.filter((_, j) => j !== i))}
+                className="text-xs text-ink-muted transition hover:text-critical"
+              >
+                Remove
+              </button>
+            }
+          >
+            <div className="space-y-4">
+              <div className="grid gap-x-4 gap-y-3 sm:grid-cols-2">
+                <label className="block">
+                  <span className="mb-1 block text-xs font-medium text-ink-secondary">Type</span>
+                  <select
+                    value={source?.type ?? 'website'}
+                    onChange={e => {
+                      // Changing type keeps the shared fields, drops type-specific ones
+                      const kept = {
+                        ...newSource(e.target.value),
+                        product_name: source?.product_name ?? '',
+                        ...(source?.version !== undefined && e.target.value !== 'code' && { version: source.version }),
+                        ...(source?.max_size !== undefined && { max_size: source.max_size }),
+                        database_config: source?.database_config ?? newSource(e.target.value).database_config,
+                      };
+                      set(['sources', i], kept);
+                    }}
+                    className={inputClass}
+                  >
+                    {Object.entries(SOURCE_TYPES).map(([key, def]) => (
+                      <option key={key} value={key}>{def.label}</option>
+                    ))}
+                  </select>
+                </label>
+                {BASE_SOURCE_FIELDS.map(field => (
+                  <FieldInput
+                    key={field.key}
+                    field={source?.type === 'code' && field.key === 'version' ? { ...field, required: false, help: 'Defaults to the branch name' } : field}
+                    value={source?.[field.key]}
+                    onChange={v => set(['sources', i, field.key], v)}
+                  />
+                ))}
+              </div>
+
+              <div>
+                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-ink-muted">{typeDef.label} options</p>
+                <FieldGrid fields={typeDef.fields} doc={doc} basePath={['sources', i]} onSet={set} />
+              </div>
+
+              <div>
+                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-ink-muted">Vector database</p>
+                <div className="grid gap-x-4 gap-y-3 sm:grid-cols-2">
+                  <label className="block">
+                    <span className="mb-1 block text-xs font-medium text-ink-secondary">Type</span>
+                    <select
+                      value={dbType}
+                      onChange={e => set(['sources', i, 'database_config'], { type: e.target.value, params: {} })}
+                      className={inputClass}
+                    >
+                      {Object.entries(DATABASE_TYPES).map(([key, def]) => (
+                        <option key={key} value={key}>{def.label}</option>
+                      ))}
+                    </select>
+                  </label>
+                  {dbDef.fields.map(field => (
+                    <FieldInput
+                      key={field.key}
+                      field={field}
+                      value={source?.database_config?.params?.[field.key]}
+                      onChange={v => set(['sources', i, 'database_config', 'params', field.key], v)}
+                    />
+                  ))}
+                </div>
+              </div>
+            </div>
+          </SectionCard>
+        );
+      })}
+
+      <button
+        onClick={() => set(['sources'], [...sources, newSource('website')])}
+        className="w-full rounded-lg border border-dashed border-edge py-2.5 text-sm font-medium text-ink-muted transition hover:border-accent hover:text-accent"
+      >
+        + Add source
+      </button>
+
+      <SectionCard
+        title="Embedding"
+        subtitle="optional — defaults to OpenAI text-embedding-3-large"
+        action={
+          <label className="flex items-center gap-2 text-xs text-ink-secondary">
+            <input
+              type="checkbox"
+              checked={embeddingEnabled}
+              onChange={e => set(['embedding'], e.target.checked ? { provider: 'openai' } : undefined)}
+              className="h-4 w-4 accent-(--accent)"
+            />
+            customize
+          </label>
+        }
+      >
+        {embeddingEnabled ? (
+          <div className="space-y-3">
+            <div className="grid gap-x-4 gap-y-3 sm:grid-cols-2">
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium text-ink-secondary">Provider</span>
+                <select
+                  value={doc.embedding?.provider ?? 'openai'}
+                  onChange={e => set(['embedding'], { provider: e.target.value })}
+                  className={inputClass}
+                >
+                  {Object.entries(EMBEDDING_PROVIDERS).map(([key, def]) => (
+                    <option key={key} value={key}>{def.label}</option>
+                  ))}
+                </select>
+              </label>
+              <FieldInput
+                field={{ key: 'dimension', label: 'Dimension', type: 'number', placeholder: '3072' }}
+                value={doc.embedding?.dimension}
+                onChange={v => set(['embedding', 'dimension'], v)}
+              />
+            </div>
+            <FieldGrid
+              fields={EMBEDDING_PROVIDERS[doc.embedding?.provider ?? 'openai'].fields}
+              doc={doc}
+              basePath={['embedding', doc.embedding?.provider ?? 'openai']}
+              onSet={set}
+            />
+          </div>
+        ) : (
+          <p className="text-xs text-ink-muted">Using defaults (OPENAI_API_KEY env var, text-embedding-3-large, 3072 dimensions).</p>
+        )}
+      </SectionCard>
+
+      <SectionCard
+        title="Markdown store"
+        subtitle="optional — store crawled markdown in Postgres"
+        action={
+          <label className="flex items-center gap-2 text-xs text-ink-secondary">
+            <input
+              type="checkbox"
+              checked={markdownStoreEnabled}
+              onChange={e => set(['markdown_store'], e.target.checked ? {} : undefined)}
+              className="h-4 w-4 accent-(--accent)"
+            />
+            enable
+          </label>
+        }
+      >
+        {markdownStoreEnabled ? (
+          <FieldGrid fields={MARKDOWN_STORE_FIELDS} doc={doc} basePath={['markdown_store']} onSet={set} />
+        ) : (
+          <p className="text-xs text-ink-muted">Disabled.</p>
+        )}
+      </SectionCard>
+
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => save.mutate()}
+          disabled={save.isPending || sources.length === 0 || missingRequired.length > 0}
+          className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {save.isPending ? 'Saving…' : props.mode === 'create' ? 'Create config' : 'Save changes'}
+        </button>
+        {props.onCancel && (
+          <button onClick={props.onCancel} className="text-sm text-ink-muted hover:text-ink-secondary">
+            Cancel
+          </button>
+        )}
+        {missingRequired.length > 0 && (
+          <span className="text-xs text-warning">missing: {missingRequired.slice(0, 3).join(', ')}{missingRequired.length > 3 ? '…' : ''}</span>
+        )}
+        {sources.length === 0 && <span className="text-xs text-warning">add at least one source</span>}
+        {props.mode === 'edit' && (
+          <span className="ml-auto text-xs text-ink-muted">Saving rewrites the YAML file (comments are not preserved).</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/LogViewer.tsx
+++ b/ui/src/components/LogViewer.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from 'react';
+import { LogRow } from '../api';
+
+const MAX_CLIENT_ROWS = 10_000;
+
+const LEVEL_CLASS: Record<string, string> = {
+  error: 'text-critical',
+  warn: 'text-warning',
+  info: 'text-ink-secondary',
+  debug: 'text-ink-muted',
+};
+
+export default function LogViewer({ runId, isActive }: { runId: number; isActive: boolean }) {
+  const [rows, setRows] = useState<LogRow[]>([]);
+  const [ended, setEnded] = useState(!isActive);
+  const [follow, setFollow] = useState(true);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const followRef = useRef(follow);
+  followRef.current = follow;
+
+  useEffect(() => {
+    setRows([]);
+    // The stream endpoint replays stored logs from seq 0, then tails live output
+    const source = new EventSource(`/api/runs/${runId}/logs/stream`);
+    source.addEventListener('log', event => {
+      const row: LogRow = JSON.parse((event as MessageEvent).data);
+      setRows(prev => {
+        const next = prev.length >= MAX_CLIENT_ROWS ? prev.slice(prev.length - MAX_CLIENT_ROWS + 1) : prev.slice();
+        next.push(row);
+        return next;
+      });
+    });
+    source.addEventListener('end', () => {
+      setEnded(true);
+      source.close();
+    });
+    source.onerror = () => {
+      // EventSource retries automatically while the controller is reachable
+    };
+    return () => source.close();
+  }, [runId]);
+
+  useEffect(() => {
+    if (followRef.current && scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [rows]);
+
+  const onScroll = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+    if (atBottom !== followRef.current) setFollow(atBottom);
+  };
+
+  return (
+    <div className="rounded-lg border border-edge bg-surface">
+      <div className="flex items-center gap-3 border-b border-edge px-4 py-2 text-xs text-ink-muted">
+        <span>{rows.length.toLocaleString()} lines{rows.length >= MAX_CLIENT_ROWS && ' (oldest trimmed)'}</span>
+        {!ended && <span className="text-accent">● live</span>}
+        {!follow && !ended && (
+          <button
+            onClick={() => {
+              setFollow(true);
+              scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+            }}
+            className="ml-auto rounded border border-edge px-2 py-0.5 hover:border-accent hover:text-accent"
+          >
+            ↓ Follow
+          </button>
+        )}
+      </div>
+      <div
+        ref={scrollRef}
+        onScroll={onScroll}
+        className="log-scroll max-h-[560px] overflow-auto px-4 py-3 font-mono text-xs leading-5"
+      >
+        {rows.length === 0 && <p className="text-ink-muted">No log output{ended ? '' : ' yet'}.</p>}
+        {rows.map(row => (
+          <div key={row.seq} className="flex gap-3 whitespace-pre-wrap break-all hover:bg-ink/[0.03]">
+            <span className="shrink-0 select-none text-ink-muted">{row.ts.slice(11, 19)}</span>
+            <span className={`shrink-0 w-10 select-none uppercase ${LEVEL_CLASS[row.level] ?? 'text-ink-secondary'}`}>
+              {row.level}
+            </span>
+            <span className={LEVEL_CLASS[row.level] ?? 'text-ink-secondary'}>
+              {row.module && <span className="text-ink-muted">[{row.module.replace(/^Doc2Vec:?/, '') || 'main'}] </span>}
+              {row.message}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/LogViewer.tsx
+++ b/ui/src/components/LogViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { LogRow } from '../api';
 
 const MAX_CLIENT_ROWS = 10_000;
@@ -64,17 +64,36 @@ export default function LogViewer({ runId, isActive }: { runId: number; isActive
     });
   }, [rows, levelFilter, keyword]);
 
-  useEffect(() => {
+  // Distinguishes our own scrollTop writes from user scrolling: during log
+  // bursts the content grows between the programmatic scroll and its async
+  // scroll event, which would otherwise measure as "not at bottom" and switch
+  // follow off spontaneously.
+  const programmaticScroll = useRef(false);
+
+  useLayoutEffect(() => {
     if (followRef.current && scrollRef.current) {
+      programmaticScroll.current = true;
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
-  }, [visibleRows]);
+  }, [visibleRows, follow]);
 
   const onScroll = () => {
     const el = scrollRef.current;
     if (!el) return;
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+    if (programmaticScroll.current) {
+      programmaticScroll.current = false;
+      // Our own scroll never disables follow; it can only confirm it
+      if (atBottom && !followRef.current) setFollow(true);
+      return;
+    }
     if (atBottom !== followRef.current) setFollow(atBottom);
+  };
+
+  // Scrolling up is an unambiguous "stop following" signal — react to the
+  // gesture itself so a heavy log burst can't re-pin the view mid-scroll
+  const onWheel = (event: React.WheelEvent) => {
+    if (event.deltaY < 0 && followRef.current) setFollow(false);
   };
 
   const toggleLevel = (level: string) => {
@@ -145,6 +164,7 @@ export default function LogViewer({ runId, isActive }: { runId: number; isActive
       <div
         ref={scrollRef}
         onScroll={onScroll}
+        onWheel={onWheel}
         className="log-scroll max-h-[560px] overflow-auto px-4 py-3 font-mono text-xs leading-5"
       >
         {visibleRows.length === 0 && (

--- a/ui/src/components/LogViewer.tsx
+++ b/ui/src/components/LogViewer.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { LogRow } from '../api';
 
 const MAX_CLIENT_ROWS = 10_000;
+const LEVELS = ['error', 'warn', 'info', 'debug'] as const;
 
 const LEVEL_CLASS: Record<string, string> = {
   error: 'text-critical',
@@ -14,6 +15,8 @@ export default function LogViewer({ runId, isActive }: { runId: number; isActive
   const [rows, setRows] = useState<LogRow[]>([]);
   const [ended, setEnded] = useState(!isActive);
   const [follow, setFollow] = useState(true);
+  const [levelFilter, setLevelFilter] = useState<Set<string>>(new Set());
+  const [keyword, setKeyword] = useState('');
   const scrollRef = useRef<HTMLDivElement>(null);
   const followRef = useRef(follow);
   followRef.current = follow;
@@ -40,11 +43,32 @@ export default function LogViewer({ runId, isActive }: { runId: number; isActive
     return () => source.close();
   }, [runId]);
 
+  const levelCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const row of rows) counts[row.level] = (counts[row.level] ?? 0) + 1;
+    return counts;
+  }, [rows]);
+
+  const visibleRows = useMemo(() => {
+    const needle = keyword.trim().toLowerCase();
+    if (levelFilter.size === 0 && !needle) return rows;
+    return rows.filter(row => {
+      if (levelFilter.size > 0 && !levelFilter.has(row.level)) return false;
+      if (needle) {
+        return (
+          row.message.toLowerCase().includes(needle) ||
+          (row.module ?? '').toLowerCase().includes(needle)
+        );
+      }
+      return true;
+    });
+  }, [rows, levelFilter, keyword]);
+
   useEffect(() => {
     if (followRef.current && scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
-  }, [rows]);
+  }, [visibleRows]);
 
   const onScroll = () => {
     const el = scrollRef.current;
@@ -53,11 +77,59 @@ export default function LogViewer({ runId, isActive }: { runId: number; isActive
     if (atBottom !== followRef.current) setFollow(atBottom);
   };
 
+  const toggleLevel = (level: string) => {
+    setLevelFilter(prev => {
+      const next = new Set(prev);
+      if (next.has(level)) next.delete(level);
+      else next.add(level);
+      return next;
+    });
+  };
+
+  const filtered = levelFilter.size > 0 || keyword.trim() !== '';
+
   return (
     <div className="rounded-lg border border-edge bg-surface">
-      <div className="flex items-center gap-3 border-b border-edge px-4 py-2 text-xs text-ink-muted">
-        <span>{rows.length.toLocaleString()} lines{rows.length >= MAX_CLIENT_ROWS && ' (oldest trimmed)'}</span>
-        {!ended && <span className="text-accent">● live</span>}
+      <div className="flex flex-wrap items-center gap-2 border-b border-edge px-4 py-2 text-xs text-ink-muted">
+        <span className="shrink-0">
+          {filtered ? `${visibleRows.length.toLocaleString()} / ` : ''}
+          {rows.length.toLocaleString()} lines{rows.length >= MAX_CLIENT_ROWS && ' (oldest trimmed)'}
+        </span>
+        {!ended && <span className="shrink-0 text-accent">● live</span>}
+        <div className="flex items-center gap-1">
+          {LEVELS.map(level => (
+            <button
+              key={level}
+              onClick={() => toggleLevel(level)}
+              title={`${levelCounts[level] ?? 0} ${level} line(s)`}
+              className={`rounded-full border px-2 py-0.5 font-medium uppercase transition ${
+                levelFilter.has(level)
+                  ? `border-current ${LEVEL_CLASS[level]}`
+                  : 'border-edge text-ink-muted hover:text-ink-secondary'
+              }`}
+            >
+              {level}
+              {(levelCounts[level] ?? 0) > 0 && <span className="ml-1 font-normal">{levelCounts[level]}</span>}
+            </button>
+          ))}
+        </div>
+        <input
+          value={keyword}
+          onChange={e => setKeyword(e.target.value)}
+          placeholder="Filter by keyword…"
+          className="w-44 rounded-md border border-edge bg-page px-2 py-1 text-xs outline-none placeholder:text-ink-muted/60 focus:border-accent"
+        />
+        {filtered && (
+          <button
+            onClick={() => {
+              setLevelFilter(new Set());
+              setKeyword('');
+            }}
+            className="text-ink-muted underline-offset-2 hover:text-accent hover:underline"
+          >
+            clear
+          </button>
+        )}
         {!follow && !ended && (
           <button
             onClick={() => {
@@ -75,11 +147,15 @@ export default function LogViewer({ runId, isActive }: { runId: number; isActive
         onScroll={onScroll}
         className="log-scroll max-h-[560px] overflow-auto px-4 py-3 font-mono text-xs leading-5"
       >
-        {rows.length === 0 && <p className="text-ink-muted">No log output{ended ? '' : ' yet'}.</p>}
-        {rows.map(row => (
+        {visibleRows.length === 0 && (
+          <p className="text-ink-muted">
+            {rows.length === 0 ? `No log output${ended ? '' : ' yet'}.` : 'No lines match the current filters.'}
+          </p>
+        )}
+        {visibleRows.map(row => (
           <div key={row.seq} className="flex gap-3 whitespace-pre-wrap break-all hover:bg-ink/[0.03]">
             <span className="shrink-0 select-none text-ink-muted">{row.ts.slice(11, 19)}</span>
-            <span className={`shrink-0 w-10 select-none uppercase ${LEVEL_CLASS[row.level] ?? 'text-ink-secondary'}`}>
+            <span className={`w-10 shrink-0 select-none uppercase ${LEVEL_CLASS[row.level] ?? 'text-ink-secondary'}`}>
               {row.level}
             </span>
             <span className={LEVEL_CLASS[row.level] ?? 'text-ink-secondary'}>

--- a/ui/src/components/RunStatusBadge.tsx
+++ b/ui/src/components/RunStatusBadge.tsx
@@ -1,0 +1,23 @@
+import { RunStatus } from '../api';
+
+// Status colors are paired with a text label + symbol — never color alone
+const STYLES: Record<RunStatus, { label: string; symbol: string; className: string }> = {
+  succeeded: { label: 'Succeeded', symbol: '✓', className: 'text-good-text border-good/40' },
+  failed: { label: 'Failed', symbol: '✕', className: 'text-critical border-critical/40' },
+  running: { label: 'Running', symbol: '●', className: 'text-accent border-accent/40 animate-pulse' },
+  queued: { label: 'Queued', symbol: '…', className: 'text-ink-secondary border-edge' },
+  skipped: { label: 'Skipped', symbol: '≫', className: 'text-warning border-warning/40' },
+  canceled: { label: 'Canceled', symbol: '⊘', className: 'text-ink-muted border-edge' },
+};
+
+export default function RunStatusBadge({ status }: { status: RunStatus }) {
+  const style = STYLES[status] ?? STYLES.queued;
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border bg-surface px-2.5 py-0.5 text-xs font-medium ${style.className}`}
+    >
+      <span aria-hidden>{style.symbol}</span>
+      {style.label}
+    </span>
+  );
+}

--- a/ui/src/components/RunsTable.tsx
+++ b/ui/src/components/RunsTable.tsx
@@ -1,0 +1,58 @@
+import { Link } from 'react-router-dom';
+import { RunRecord } from '../api';
+import { formatTime, runDuration } from '../lib/format';
+import RunStatusBadge from './RunStatusBadge';
+
+export default function RunsTable({ runs, showConfig = false, configNames }: {
+  runs: RunRecord[];
+  showConfig?: boolean;
+  configNames?: Map<number, string>;
+}) {
+  if (runs.length === 0) {
+    return <p className="py-8 text-center text-sm text-ink-muted">No runs yet.</p>;
+  }
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-edge text-left text-xs uppercase tracking-wide text-ink-muted">
+            <th className="py-2 pr-4 font-medium">Run</th>
+            {showConfig && <th className="py-2 pr-4 font-medium">Config</th>}
+            <th className="py-2 pr-4 font-medium">Status</th>
+            <th className="py-2 pr-4 font-medium">Trigger</th>
+            <th className="py-2 pr-4 font-medium">Started</th>
+            <th className="py-2 pr-4 font-medium">Duration</th>
+            <th className="py-2 font-medium">Detail</th>
+          </tr>
+        </thead>
+        <tbody>
+          {runs.map(run => (
+            <tr key={run.id} className="border-b border-edge/60 hover:bg-ink/[0.03]">
+              <td className="py-2.5 pr-4">
+                <Link to={`/runs/${run.id}`} className="font-medium text-accent hover:underline">
+                  #{run.id}
+                </Link>
+              </td>
+              {showConfig && (
+                <td className="py-2.5 pr-4">
+                  <Link to={`/configs/${run.config_id}`} className="hover:underline">
+                    {configNames?.get(run.config_id) ?? run.config_name ?? `config ${run.config_id}`}
+                  </Link>
+                </td>
+              )}
+              <td className="py-2.5 pr-4"><RunStatusBadge status={run.status} /></td>
+              <td className="py-2.5 pr-4 text-ink-secondary">{run.trigger}</td>
+              <td className="py-2.5 pr-4 text-ink-secondary">{formatTime(run.started_at ?? run.queued_at)}</td>
+              <td className="py-2.5 pr-4 text-ink-secondary">
+                {run.status === 'running' || run.status === 'queued' ? '…' : runDuration(run.started_at, run.finished_at)}
+              </td>
+              <td className="max-w-md truncate py-2.5 text-ink-muted" title={run.error ?? undefined}>
+                {run.error ?? (run.stats?.sources ? `${run.stats.sources.length} source(s)` : '')}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/ui/src/components/SourceBadges.tsx
+++ b/ui/src/components/SourceBadges.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { SourceSummary } from '../api';
+
+const TYPE_ICONS: Record<string, string> = {
+  website: '🌐',
+  github: '🐙',
+  zendesk: '🎫',
+  local_directory: '📁',
+  code: '⌨️',
+  s3: '🪣',
+};
+
+export default function SourceBadges({ sources, max }: { sources: SourceSummary[]; max?: number }) {
+  const [expanded, setExpanded] = useState(false);
+  if (sources.length === 0) return <span className="text-xs text-ink-muted">no sources</span>;
+
+  const limit = expanded || max === undefined ? sources.length : max;
+  const shown = sources.slice(0, limit);
+  const hidden = sources.length - shown.length;
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {shown.map((source, i) => (
+        <span
+          key={`${source.product_name}-${source.type}-${i}`}
+          title={`${source.type}${source.version ? ` · ${source.version}` : ''}`}
+          className="inline-flex items-center gap-1 rounded-full border border-edge bg-page px-2 py-0.5 text-xs text-ink-secondary"
+        >
+          <span aria-hidden className="text-[10px]">{TYPE_ICONS[source.type] ?? '•'}</span>
+          {source.product_name}
+          <span className="text-ink-muted">{source.type}</span>
+        </span>
+      ))}
+      {hidden > 0 && (
+        <button
+          onClick={e => {
+            e.preventDefault();
+            setExpanded(true);
+          }}
+          className="rounded-full border border-edge px-2 py-0.5 text-xs text-ink-muted transition hover:border-accent hover:text-accent"
+        >
+          +{hidden} more
+        </button>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/StatsCharts.tsx
+++ b/ui/src/components/StatsCharts.tsx
@@ -1,0 +1,156 @@
+import { useMemo } from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { ConfigStats } from '../api';
+import { formatDuration } from '../lib/format';
+
+// Status palette (dataviz reference): reserved status colors, never reused as series
+const STATUS_COLORS: Record<string, string> = {
+  succeeded: 'var(--status-good)',
+  failed: 'var(--status-critical)',
+  skipped: 'var(--status-warning)',
+  canceled: 'var(--text-muted)',
+};
+const STACK_ORDER = ['succeeded', 'failed', 'skipped', 'canceled'] as const;
+
+function StatTile({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="rounded-lg border border-edge bg-surface px-4 py-3">
+      <p className="text-xs uppercase tracking-wide text-ink-muted">{label}</p>
+      <p className="mt-1 text-2xl font-semibold">{value}</p>
+      {sub && <p className="mt-0.5 text-xs text-ink-muted">{sub}</p>}
+    </div>
+  );
+}
+
+function ChartTooltip({ active, payload, label, unit }: any) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="rounded-md border border-edge bg-surface px-3 py-2 text-xs shadow-sm">
+      <p className="mb-1 font-medium text-ink-secondary">{label}</p>
+      {payload.map((entry: any) => (
+        <p key={entry.dataKey} className="flex items-center gap-2 text-ink-secondary">
+          <span className="inline-block h-2 w-2 rounded-full" style={{ background: entry.color }} />
+          {entry.name}: <span className="font-medium text-ink">{unit === 's' ? formatDuration(entry.value) : entry.value}</span>
+        </p>
+      ))}
+    </div>
+  );
+}
+
+export default function StatsCharts({ stats }: { stats: ConfigStats }) {
+  const dailyData = useMemo(() => {
+    const byDay = new Map<string, Record<string, number | string>>();
+    for (const row of stats.daily) {
+      const entry = byDay.get(row.day) ?? { day: row.day.slice(5) };
+      entry[row.status] = row.count;
+      byDay.set(row.day, entry);
+    }
+    return [...byDay.values()];
+  }, [stats.daily]);
+
+  const durationData = useMemo(
+    () =>
+      stats.recentDurations.map(r => ({
+        id: `#${r.id}`,
+        duration: Math.round(r.duration_s * 10) / 10,
+      })),
+    [stats.recentDurations]
+  );
+
+  const successRate = stats.totals.total > 0
+    ? Math.round((stats.totals.succeeded / Math.max(stats.totals.total - stats.totals.skipped, 1)) * 100)
+    : null;
+  const avgDuration = stats.recentDurations.length > 0
+    ? stats.recentDurations.reduce((acc, r) => acc + r.duration_s, 0) / stats.recentDurations.length
+    : null;
+
+  const axisTick = { fill: 'var(--text-muted)', fontSize: 11 };
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        <StatTile label="Runs" value={String(stats.totals.total)} />
+        <StatTile
+          label="Success rate"
+          value={successRate === null ? '—' : `${successRate}%`}
+          sub={stats.totals.failed > 0 ? `${stats.totals.failed} failed` : undefined}
+        />
+        <StatTile label="Skipped" value={String(stats.totals.skipped)} sub="overlapping schedule" />
+        <StatTile label="Avg duration" value={avgDuration === null ? '—' : formatDuration(avgDuration)} sub="last 50 runs" />
+      </div>
+
+      <div className="rounded-lg border border-edge bg-surface p-4">
+        <h3 className="mb-3 text-sm font-semibold text-ink-secondary">Runs per day</h3>
+        {dailyData.length === 0 ? (
+          <p className="py-10 text-center text-sm text-ink-muted">No runs in this period.</p>
+        ) : (
+          <ResponsiveContainer width="100%" height={220}>
+            <BarChart data={dailyData} margin={{ top: 4, right: 8, left: -18, bottom: 0 }}>
+              <CartesianGrid vertical={false} stroke="var(--gridline)" />
+              <XAxis dataKey="day" tick={axisTick} axisLine={{ stroke: 'var(--baseline)' }} tickLine={false} />
+              <YAxis tick={axisTick} axisLine={false} tickLine={false} allowDecimals={false} />
+              <Tooltip content={<ChartTooltip />} cursor={{ fill: 'var(--gridline)', opacity: 0.4 }} />
+              <Legend wrapperStyle={{ fontSize: 12, color: 'var(--text-secondary)' }} iconSize={8} />
+              {STACK_ORDER.map((status, i) => (
+                <Bar
+                  key={status}
+                  dataKey={status}
+                  name={status}
+                  stackId="runs"
+                  fill={STATUS_COLORS[status]}
+                  stroke="var(--surface-1)"
+                  strokeWidth={1}
+                  maxBarSize={28}
+                  radius={i === STACK_ORDER.length - 1 ? [3, 3, 0, 0] : undefined}
+                  isAnimationActive={false}
+                />
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      <div className="rounded-lg border border-edge bg-surface p-4">
+        <h3 className="mb-3 text-sm font-semibold text-ink-secondary">Run duration (last {durationData.length} runs)</h3>
+        {durationData.length === 0 ? (
+          <p className="py-10 text-center text-sm text-ink-muted">No finished runs yet.</p>
+        ) : (
+          <ResponsiveContainer width="100%" height={200}>
+            <LineChart data={durationData} margin={{ top: 4, right: 8, left: -10, bottom: 0 }}>
+              <CartesianGrid vertical={false} stroke="var(--gridline)" />
+              <XAxis dataKey="id" tick={axisTick} axisLine={{ stroke: 'var(--baseline)' }} tickLine={false} />
+              <YAxis
+                tick={axisTick}
+                axisLine={false}
+                tickLine={false}
+                tickFormatter={(v: number) => formatDuration(v)}
+              />
+              <Tooltip content={<ChartTooltip unit="s" />} cursor={{ stroke: 'var(--baseline)' }} />
+              <Line
+                type="monotone"
+                dataKey="duration"
+                name="duration"
+                stroke="var(--series-1)"
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 4, strokeWidth: 2, stroke: 'var(--surface-1)' }}
+                isAnimationActive={false}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,0 +1,72 @@
+@import "tailwindcss";
+
+/* Theme tokens — light values, swapped for dark below (dataviz reference palette) */
+:root {
+  --page: #f9f9f7;
+  --surface-1: #fcfcfb;
+  --text-primary: #0b0b0b;
+  --text-secondary: #52514e;
+  --text-muted: #898781;
+  --gridline: #e1e0d9;
+  --baseline: #c3c2b7;
+  --border: rgba(11, 11, 11, 0.1);
+  --series-1: #2a78d6;
+  --status-good: #0ca30c;
+  --status-warning: #fab219;
+  --status-critical: #d03b3b;
+  --good-text: #006300;
+  --accent: #2a78d6;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page: #0d0d0d;
+    --surface-1: #1a1a19;
+    --text-primary: #ffffff;
+    --text-secondary: #c3c2b7;
+    --text-muted: #898781;
+    --gridline: #2c2c2a;
+    --baseline: #383835;
+    --border: rgba(255, 255, 255, 0.1);
+    --series-1: #3987e5;
+    --status-good: #0ca30c;
+    --status-warning: #fab219;
+    --status-critical: #d03b3b;
+    --good-text: #0ca30c;
+    --accent: #3987e5;
+  }
+}
+
+@theme inline {
+  --color-page: var(--page);
+  --color-surface: var(--surface-1);
+  --color-ink: var(--text-primary);
+  --color-ink-secondary: var(--text-secondary);
+  --color-ink-muted: var(--text-muted);
+  --color-gridline: var(--gridline);
+  --color-baseline: var(--baseline);
+  --color-edge: var(--border);
+  --color-series1: var(--series-1);
+  --color-good: var(--status-good);
+  --color-warning: var(--status-warning);
+  --color-critical: var(--status-critical);
+  --color-good-text: var(--good-text);
+  --color-accent: var(--accent);
+  --font-sans: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+html {
+  background: var(--page);
+  color: var(--text-primary);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+/* Log viewer scrollbar stays subtle in both modes */
+.log-scroll::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+.log-scroll::-webkit-scrollbar-thumb {
+  background: var(--baseline);
+  border-radius: 5px;
+}

--- a/ui/src/lib/config-schema.ts
+++ b/ui/src/lib/config-schema.ts
@@ -1,0 +1,149 @@
+// Declarative description of the doc2vec config format (mirrors ../../types.ts).
+// The ConfigForm renders entirely from these definitions, so adding a field here
+// is all it takes to expose it in the UI.
+
+export type FieldType = 'string' | 'number' | 'boolean' | 'string_list' | 'select';
+
+export interface FieldDef {
+  key: string;
+  label: string;
+  type: FieldType;
+  required?: boolean;
+  options?: string[];      // for select fields
+  placeholder?: string;
+  help?: string;
+  secret?: boolean;        // suggests using a ${ENV_VAR} placeholder
+}
+
+/** Fields shared by every source type (type itself is handled separately). */
+export const BASE_SOURCE_FIELDS: FieldDef[] = [
+  { key: 'product_name', label: 'Product name', type: 'string', required: true, placeholder: 'istio', help: 'Stored in chunk metadata; used to identify the source' },
+  { key: 'version', label: 'Version', type: 'string', required: true, placeholder: 'latest', help: 'Required for all types except code (defaults to branch)' },
+  { key: 'max_size', label: 'Max page size (bytes)', type: 'number', placeholder: '1048576', help: 'Pages/files larger than this are skipped' },
+];
+
+export const SOURCE_TYPES: Record<string, { label: string; fields: FieldDef[] }> = {
+  website: {
+    label: 'Website',
+    fields: [
+      { key: 'url', label: 'Base URL', type: 'string', required: true, placeholder: 'https://docs.example.com/' },
+      { key: 'sitemap_url', label: 'Sitemap URL', type: 'string', placeholder: 'https://docs.example.com/sitemap.xml', help: 'Discovers pages not linked in navigation; lastmod dates enable cheap change detection' },
+      { key: 'markdown_store', label: 'Store markdown in Postgres', type: 'boolean', help: 'Requires the top-level markdown store to be configured' },
+    ],
+  },
+  github: {
+    label: 'GitHub issues',
+    fields: [
+      { key: 'repo', label: 'Repository', type: 'string', required: true, placeholder: 'owner/repo' },
+      { key: 'start_date', label: 'Start date', type: 'string', placeholder: '2025-01-01', help: 'Only issues updated after this date (first run)' },
+    ],
+  },
+  local_directory: {
+    label: 'Local directory',
+    fields: [
+      { key: 'path', label: 'Directory path', type: 'string', required: true, placeholder: '/data/docs' },
+      { key: 'include_extensions', label: 'Include extensions', type: 'string_list', placeholder: '.md, .txt, .pdf' },
+      { key: 'exclude_extensions', label: 'Exclude extensions', type: 'string_list', placeholder: '.log, .tmp' },
+      { key: 'recursive', label: 'Recurse into subdirectories', type: 'boolean' },
+      { key: 'encoding', label: 'File encoding', type: 'string', placeholder: 'utf8' },
+      { key: 'url_rewrite_prefix', label: 'URL rewrite prefix', type: 'string', placeholder: 'https://mydomain.com', help: 'Rewrites file:// URLs in chunk metadata' },
+    ],
+  },
+  zendesk: {
+    label: 'Zendesk',
+    fields: [
+      { key: 'zendesk_subdomain', label: 'Subdomain', type: 'string', required: true, placeholder: 'mycompany', help: 'mycompany.zendesk.com' },
+      { key: 'email', label: 'User email', type: 'string', required: true, placeholder: 'agent@company.com' },
+      { key: 'api_token', label: 'API token', type: 'string', required: true, secret: true, placeholder: '${ZENDESK_API_TOKEN}' },
+      { key: 'fetch_tickets', label: 'Fetch tickets', type: 'boolean' },
+      { key: 'fetch_articles', label: 'Fetch help center articles', type: 'boolean' },
+      { key: 'start_date', label: 'Start date', type: 'string', placeholder: '2025-01-01' },
+      { key: 'ticket_status', label: 'Ticket statuses', type: 'string_list', placeholder: 'new, open, pending, hold, solved' },
+      { key: 'ticket_priority', label: 'Ticket priorities', type: 'string_list', placeholder: 'urgent, high' },
+      { key: 'excluded_organizations', label: 'Excluded organizations', type: 'string_list' },
+      { key: 'include_internal_comments', label: 'Include internal comments', type: 'boolean' },
+    ],
+  },
+  code: {
+    label: 'Code',
+    fields: [
+      { key: 'source', label: 'Code source', type: 'select', required: true, options: ['github', 'local_directory'] },
+      { key: 'repo', label: 'Repository', type: 'string', placeholder: 'owner/repo', help: 'When source is github' },
+      { key: 'branch', label: 'Branch', type: 'string', placeholder: 'main', help: 'When source is github' },
+      { key: 'path', label: 'Directory path', type: 'string', placeholder: '/data/src', help: 'When source is local_directory' },
+      { key: 'include_extensions', label: 'Include extensions', type: 'string_list', placeholder: '.ts, .go, .py' },
+      { key: 'exclude_extensions', label: 'Exclude extensions', type: 'string_list' },
+      { key: 'recursive', label: 'Recurse into subdirectories', type: 'boolean' },
+      { key: 'chunk_size', label: 'Chunk size (tokens)', type: 'number', placeholder: '1500' },
+      { key: 'url_rewrite_prefix', label: 'URL rewrite prefix', type: 'string' },
+    ],
+  },
+  s3: {
+    label: 'S3 bucket',
+    fields: [
+      { key: 'bucket', label: 'Bucket', type: 'string', required: true, placeholder: 'my-docs-bucket' },
+      { key: 'prefix', label: 'Key prefix', type: 'string', placeholder: 'docs/' },
+      { key: 'region', label: 'Region', type: 'string', placeholder: 'us-east-1' },
+      { key: 'endpoint', label: 'Custom endpoint', type: 'string', placeholder: 'https://minio.local:9000', help: 'For S3-compatible services (MinIO, LocalStack)' },
+      { key: 'include_extensions', label: 'Include extensions', type: 'string_list', placeholder: '.md, .txt, .pdf' },
+      { key: 'exclude_extensions', label: 'Exclude extensions', type: 'string_list' },
+      { key: 'encoding', label: 'Text encoding', type: 'string', placeholder: 'utf8' },
+      { key: 'url_rewrite_prefix', label: 'URL rewrite prefix', type: 'string', help: 'Rewrites s3:// URLs in chunk metadata' },
+    ],
+  },
+};
+
+export const DATABASE_TYPES: Record<string, { label: string; fields: FieldDef[] }> = {
+  sqlite: {
+    label: 'SQLite (sqlite-vec)',
+    fields: [
+      { key: 'db_path', label: 'Database file', type: 'string', placeholder: './my-product.db' },
+    ],
+  },
+  qdrant: {
+    label: 'Qdrant',
+    fields: [
+      { key: 'qdrant_url', label: 'Qdrant URL', type: 'string', placeholder: 'http://localhost' },
+      { key: 'qdrant_port', label: 'Port', type: 'number', placeholder: '6333' },
+      { key: 'collection_name', label: 'Collection', type: 'string', placeholder: 'my-product' },
+    ],
+  },
+};
+
+export const EMBEDDING_PROVIDERS: Record<string, { label: string; fields: FieldDef[] }> = {
+  openai: {
+    label: 'OpenAI (or compatible)',
+    fields: [
+      { key: 'api_key', label: 'API key', type: 'string', secret: true, placeholder: '${OPENAI_API_KEY}', help: 'Falls back to the OPENAI_API_KEY env var' },
+      { key: 'model', label: 'Model', type: 'string', placeholder: 'text-embedding-3-large' },
+      { key: 'base_url', label: 'Base URL', type: 'string', placeholder: 'http://localhost:11434/v1', help: 'For Ollama or other OpenAI-compatible endpoints' },
+    ],
+  },
+  azure: {
+    label: 'Azure OpenAI',
+    fields: [
+      { key: 'api_key', label: 'API key', type: 'string', secret: true, placeholder: '${AZURE_OPENAI_KEY}' },
+      { key: 'endpoint', label: 'Endpoint', type: 'string', placeholder: 'https://myresource.openai.azure.com' },
+      { key: 'deployment_name', label: 'Deployment name', type: 'string', placeholder: 'text-embedding-3-large' },
+      { key: 'api_version', label: 'API version', type: 'string', placeholder: '2024-10-21' },
+    ],
+  },
+};
+
+export const MARKDOWN_STORE_FIELDS: FieldDef[] = [
+  { key: 'connection_string', label: 'Connection string', type: 'string', secret: true, placeholder: 'postgres://user:${PG_PASSWORD}@host:5432/db', help: 'Either this, or the discrete fields below' },
+  { key: 'host', label: 'Host', type: 'string' },
+  { key: 'port', label: 'Port', type: 'number', placeholder: '5432' },
+  { key: 'database', label: 'Database', type: 'string' },
+  { key: 'user', label: 'User', type: 'string' },
+  { key: 'password', label: 'Password', type: 'string', secret: true, placeholder: '${PG_PASSWORD}' },
+  { key: 'table_name', label: 'Table name', type: 'string', placeholder: 'markdown_pages' },
+];
+
+/** A minimal new source of the given type, pre-filled with sensible defaults. */
+export function newSource(type: string): Record<string, any> {
+  const source: Record<string, any> = { type, product_name: '', version: 'latest', max_size: 1048576 };
+  if (type === 'code') delete source.version;
+  source.database_config = { type: 'sqlite', params: { db_path: '' } };
+  return source;
+}

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -1,0 +1,47 @@
+import cronstrue from 'cronstrue';
+
+export function formatDuration(seconds: number | null | undefined): string {
+  if (seconds === null || seconds === undefined || !isFinite(seconds)) return '—';
+  if (seconds < 1) return '<1s';
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ${Math.round(seconds % 60)}s`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
+}
+
+export function runDuration(started: string | null, finished: string | null): string {
+  if (!started) return '—';
+  const end = finished ? new Date(finished).getTime() : Date.now();
+  return formatDuration((end - new Date(started).getTime()) / 1000);
+}
+
+export function formatTime(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export function relativeTime(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const deltaMs = new Date(iso).getTime() - Date.now();
+  const abs = Math.abs(deltaMs);
+  const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+  if (abs < 60_000) return rtf.format(Math.round(deltaMs / 1000), 'second');
+  if (abs < 3_600_000) return rtf.format(Math.round(deltaMs / 60_000), 'minute');
+  if (abs < 86_400_000) return rtf.format(Math.round(deltaMs / 3_600_000), 'hour');
+  return rtf.format(Math.round(deltaMs / 86_400_000), 'day');
+}
+
+export function humanizeCron(expr: string | null): string {
+  if (!expr) return 'Manual only';
+  try {
+    return cronstrue.toString(expr, { verbose: false });
+  } catch {
+    return expr;
+  }
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      staleTime: 5_000,
+    },
+  },
+});
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/ui/src/pages/ConfigDetail.tsx
+++ b/ui/src/pages/ConfigDetail.tsx
@@ -1,0 +1,198 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { api, ApiError } from '../api';
+import { formatTime, humanizeCron, relativeTime } from '../lib/format';
+import ConfigEditor from '../components/ConfigEditor';
+import ConfigForm from '../components/ConfigForm';
+import RunsTable from '../components/RunsTable';
+import SourceBadges from '../components/SourceBadges';
+import StatsCharts from '../components/StatsCharts';
+
+type Tab = 'runs' | 'stats' | 'config';
+
+export default function ConfigDetail() {
+  const { id } = useParams();
+  const configId = Number(id);
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [tab, setTab] = useState<Tab>('runs');
+  const [statsDays, setStatsDays] = useState(30);
+  const [configView, setConfigView] = useState<'form' | 'yaml'>('form');
+
+  const { data: config, error } = useQuery({
+    queryKey: ['configs', configId],
+    queryFn: () => api.config(configId),
+  });
+  const { data: health } = useQuery({ queryKey: ['health'], queryFn: api.health });
+  const { data: runs } = useQuery({
+    queryKey: ['runs', { configId }],
+    queryFn: () => api.runs({ configId, limit: 100 }),
+  });
+  const { data: stats } = useQuery({
+    queryKey: ['runs', 'stats', configId, statsDays],
+    queryFn: () => api.configStats(configId, statsDays),
+    enabled: tab === 'stats',
+  });
+
+  const trigger = useMutation({
+    mutationFn: () => api.triggerRun(configId),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['configs'] }),
+  });
+  const remove = useMutation({
+    mutationFn: () => api.deleteConfig(configId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['configs'] });
+      navigate('/');
+    },
+  });
+
+  if (error) return <p className="text-critical">{(error as ApiError).message}</p>;
+  if (!config) return <p className="text-ink-muted">Loading…</p>;
+
+  const readWrite = health?.mode === 'rw';
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link to="/" className="text-sm text-ink-muted hover:text-accent">← Configurations</Link>
+        <div className="mt-2 flex flex-wrap items-center gap-3">
+          <h1 className="text-xl font-semibold tracking-tight">{config.name}</h1>
+          {config.parse_error && (
+            <span className="rounded-full border border-critical/40 px-2 py-0.5 text-xs text-critical" title={config.parse_error}>
+              invalid: {config.parse_error}
+            </span>
+          )}
+          <div className="ml-auto flex items-center gap-2">
+            <button
+              onClick={() => trigger.mutate()}
+              disabled={config.busy || !!config.parse_error || trigger.isPending}
+              className="rounded-md bg-accent px-3.5 py-1.5 text-sm font-medium text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {config.busy ? 'Running…' : 'Run now'}
+            </button>
+            {readWrite && (
+              <button
+                onClick={() => {
+                  if (window.confirm(`Delete config '${config.name}' and its file?\n\nRun history is kept.`)) {
+                    remove.mutate();
+                  }
+                }}
+                className="rounded-md border border-critical/40 px-3.5 py-1.5 text-sm font-medium text-critical transition hover:bg-critical/10"
+              >
+                Delete
+              </button>
+            )}
+          </div>
+        </div>
+        {trigger.error && <p className="mt-2 text-sm text-critical">{(trigger.error as ApiError).message}</p>}
+        {remove.error && <p className="mt-2 text-sm text-critical">{(remove.error as ApiError).message}</p>}
+        <dl className="mt-3 flex flex-wrap gap-x-8 gap-y-2 text-sm">
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-ink-muted">Schedule</dt>
+            <dd className="mt-0.5 text-ink-secondary">
+              {humanizeCron(config.schedule)}
+              {config.schedule && <code className="ml-2 text-xs text-ink-muted">{config.schedule}</code>}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-ink-muted">Next run</dt>
+            <dd className="mt-0.5 text-ink-secondary" title={config.next_run ? formatTime(config.next_run) : undefined}>
+              {config.next_run ? relativeTime(config.next_run) : '—'}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-ink-muted">File</dt>
+            <dd className="mt-0.5 font-mono text-xs text-ink-muted">{config.path}</dd>
+          </div>
+        </dl>
+        <div className="mt-3">
+          <SourceBadges sources={config.source_summary} />
+        </div>
+      </div>
+
+      <div className="border-b border-edge">
+        <nav className="flex gap-6 text-sm">
+          {(['runs', 'stats', 'config'] as Tab[]).map(t => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`-mb-px border-b-2 px-1 pb-2 font-medium capitalize transition ${
+                tab === t ? 'border-accent text-accent' : 'border-transparent text-ink-muted hover:text-ink-secondary'
+              }`}
+            >
+              {t}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {tab === 'runs' && <RunsTable runs={runs ?? []} />}
+
+      {tab === 'stats' && (
+        <div className="space-y-4">
+          <div className="flex items-center gap-2 text-sm">
+            <span className="text-ink-muted">Period:</span>
+            {[7, 30, 90].map(days => (
+              <button
+                key={days}
+                onClick={() => setStatsDays(days)}
+                className={`rounded-md border px-2.5 py-1 text-xs font-medium transition ${
+                  statsDays === days
+                    ? 'border-accent text-accent'
+                    : 'border-edge text-ink-muted hover:text-ink-secondary'
+                }`}
+              >
+                {days}d
+              </button>
+            ))}
+          </div>
+          {stats ? <StatsCharts stats={stats} /> : <p className="text-ink-muted">Loading…</p>}
+        </div>
+      )}
+
+      {tab === 'config' && (
+        <div className="space-y-4">
+          <div className="flex items-center gap-2 text-sm">
+            {readWrite ? (
+              (['form', 'yaml'] as const).map(view => (
+                <button
+                  key={view}
+                  onClick={() => setConfigView(view)}
+                  className={`rounded-md border px-2.5 py-1 text-xs font-medium uppercase transition ${
+                    configView === view
+                      ? 'border-accent text-accent'
+                      : 'border-edge text-ink-muted hover:text-ink-secondary'
+                  }`}
+                >
+                  {view}
+                </button>
+              ))
+            ) : (
+              <p className="text-xs text-ink-muted">
+                Read-only mode — configs are managed from the files passed to the controller.
+              </p>
+            )}
+          </div>
+          {readWrite && configView === 'form' ? (
+            <ConfigForm
+              key={config.content_hash}
+              mode="edit"
+              config={config}
+              onSaved={() => queryClient.invalidateQueries({ queryKey: ['configs', configId] })}
+            />
+          ) : readWrite ? (
+            <ConfigEditor
+              key={config.content_hash}
+              mode="edit"
+              config={config}
+              onSaved={() => queryClient.invalidateQueries({ queryKey: ['configs', configId] })}
+            />
+          ) : (
+            <ConfigEditor mode="view" config={config} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,0 +1,156 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Link, useNavigate } from 'react-router-dom';
+import { api, ApiError, ConfigRecord } from '../api';
+import { formatTime, humanizeCron, relativeTime, runDuration } from '../lib/format';
+import RunStatusBadge from '../components/RunStatusBadge';
+import ConfigForm from '../components/ConfigForm';
+import SourceBadges from '../components/SourceBadges';
+
+function RunNowButton({ config }: { config: ConfigRecord }) {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: () => api.triggerRun(config.id),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['configs'] }),
+  });
+  const disabled = config.busy || !!config.parse_error || mutation.isPending;
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        onClick={e => {
+          e.preventDefault();
+          mutation.mutate();
+        }}
+        disabled={disabled}
+        className="rounded-md border border-edge bg-surface px-3 py-1 text-xs font-medium text-ink-secondary transition hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        {config.busy ? 'Running…' : 'Run now'}
+      </button>
+      {mutation.error && (
+        <span className="text-xs text-critical">{(mutation.error as ApiError).message}</span>
+      )}
+    </div>
+  );
+}
+
+export default function Dashboard() {
+  const navigate = useNavigate();
+  const { data: configs, isLoading, error } = useQuery({ queryKey: ['configs'], queryFn: api.configs });
+  const { data: health } = useQuery({ queryKey: ['health'], queryFn: api.health });
+  const [creating, setCreating] = useState(false);
+
+  const running = configs?.filter(c => c.last_run?.status === 'running' || c.last_run?.status === 'queued') ?? [];
+
+  if (isLoading) return <p className="text-ink-muted">Loading…</p>;
+  if (error) return <p className="text-critical">Failed to load configs: {String((error as Error).message)}</p>;
+
+  return (
+    <div className="space-y-6">
+      {running.length > 0 && (
+        <div className="rounded-lg border border-accent/30 bg-surface px-4 py-3">
+          <p className="text-sm text-ink-secondary">
+            <span className="font-medium text-accent">● {running.length} config{running.length > 1 ? 's' : ''} syncing now</span>
+            {' — '}
+            {running.map((c, i) => (
+              <span key={c.id}>
+                {i > 0 && ', '}
+                <Link to={`/runs/${c.last_run!.id}`} className="text-accent hover:underline">{c.name}</Link>
+              </span>
+            ))}
+          </p>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold tracking-tight">Configurations</h1>
+        {health?.mode === 'rw' && (
+          <button
+            onClick={() => setCreating(true)}
+            className="rounded-md bg-accent px-3.5 py-1.5 text-sm font-medium text-white transition hover:opacity-90"
+          >
+            New config
+          </button>
+        )}
+      </div>
+
+      {creating && (
+        <div className="rounded-lg border border-edge bg-page p-4">
+          <h2 className="mb-4 text-sm font-semibold">Create a new config</h2>
+          <ConfigForm
+            mode="create"
+            onSaved={record => {
+              setCreating(false);
+              navigate(`/configs/${record.id}`);
+            }}
+            onCancel={() => setCreating(false)}
+          />
+        </div>
+      )}
+
+      {configs && configs.length === 0 && (
+        <p className="rounded-lg border border-edge bg-surface px-4 py-8 text-center text-sm text-ink-muted">
+          No configs loaded. Pass config files to <code className="text-ink-secondary">doc2vec controller</code>
+          {health?.mode === 'rw' && ' or create one with the button above'}.
+        </p>
+      )}
+
+      <div className="grid gap-4">
+        {configs?.map(config => (
+          <Link
+            key={config.id}
+            to={`/configs/${config.id}`}
+            className="block rounded-lg border border-edge bg-surface p-4 transition hover:border-accent/50"
+          >
+            <div className="flex flex-wrap items-start gap-x-6 gap-y-3">
+              <div className="min-w-48 flex-1">
+                <div className="flex items-center gap-2">
+                  <h2 className="font-semibold">{config.name}</h2>
+                  {config.parse_error && (
+                    <span className="rounded-full border border-critical/40 px-2 py-0.5 text-xs text-critical" title={config.parse_error}>
+                      invalid
+                    </span>
+                  )}
+                </div>
+                <div className="mt-1.5">
+                  <SourceBadges sources={config.source_summary} max={4} />
+                </div>
+              </div>
+              <div className="text-sm">
+                <p className="text-xs uppercase tracking-wide text-ink-muted">Schedule</p>
+                <p className="mt-0.5 text-ink-secondary" title={config.schedule ?? undefined}>
+                  {humanizeCron(config.schedule)}
+                </p>
+              </div>
+              <div className="text-sm">
+                <p className="text-xs uppercase tracking-wide text-ink-muted">Last run</p>
+                <div className="mt-0.5 flex items-center gap-2">
+                  {config.last_run ? (
+                    <>
+                      <RunStatusBadge status={config.last_run.status} />
+                      <span className="text-xs text-ink-muted" title={formatTime(config.last_run.queued_at)}>
+                        {relativeTime(config.last_run.finished_at ?? config.last_run.queued_at)}
+                        {config.last_run.finished_at && config.last_run.started_at &&
+                          ` · ${runDuration(config.last_run.started_at, config.last_run.finished_at)}`}
+                      </span>
+                    </>
+                  ) : (
+                    <span className="text-xs text-ink-muted">never</span>
+                  )}
+                </div>
+              </div>
+              <div className="text-sm">
+                <p className="text-xs uppercase tracking-wide text-ink-muted">Next run</p>
+                <p className="mt-0.5 text-ink-secondary" title={config.next_run ? formatTime(config.next_run) : undefined}>
+                  {config.next_run ? relativeTime(config.next_run) : '—'}
+                </p>
+              </div>
+              <div className="ml-auto self-center">
+                <RunNowButton config={config} />
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/RunDetail.tsx
+++ b/ui/src/pages/RunDetail.tsx
@@ -1,0 +1,109 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Link, useParams } from 'react-router-dom';
+import { api, ApiError } from '../api';
+import { formatDuration, formatTime, runDuration } from '../lib/format';
+import LogViewer from '../components/LogViewer';
+import RunStatusBadge from '../components/RunStatusBadge';
+
+export default function RunDetail() {
+  const { id } = useParams();
+  const runId = Number(id);
+  const queryClient = useQueryClient();
+
+  const { data: run, error } = useQuery({
+    queryKey: ['runs', runId],
+    queryFn: () => api.run(runId),
+    refetchInterval: query =>
+      query.state.data && ['queued', 'running'].includes(query.state.data.status) ? 3000 : false,
+  });
+
+  const cancel = useMutation({
+    mutationFn: () => api.cancelRun(runId),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['runs', runId] }),
+  });
+
+  if (error) return <p className="text-critical">{(error as ApiError).message}</p>;
+  if (!run) return <p className="text-ink-muted">Loading…</p>;
+
+  const active = run.status === 'queued' || run.status === 'running';
+  const sources = run.stats?.sources ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link to={`/configs/${run.config_id}`} className="text-sm text-ink-muted hover:text-accent">
+          ← {run.config_name ?? `Config ${run.config_id}`}
+        </Link>
+        <div className="mt-2 flex flex-wrap items-center gap-3">
+          <h1 className="text-xl font-semibold tracking-tight">Run #{run.id}</h1>
+          <RunStatusBadge status={run.status} />
+          {active && (
+            <button
+              onClick={() => cancel.mutate()}
+              disabled={cancel.isPending}
+              className="ml-auto rounded-md border border-critical/40 px-3.5 py-1.5 text-sm font-medium text-critical transition hover:bg-critical/10 disabled:opacity-40"
+            >
+              Cancel run
+            </button>
+          )}
+        </div>
+        {run.error && <p className="mt-2 text-sm text-critical">{run.error}</p>}
+        {cancel.error && <p className="mt-2 text-sm text-critical">{(cancel.error as ApiError).message}</p>}
+        <dl className="mt-3 flex flex-wrap gap-x-8 gap-y-2 text-sm">
+          {[
+            ['Trigger', run.trigger],
+            ['Queued', formatTime(run.queued_at)],
+            ['Started', formatTime(run.started_at)],
+            ['Duration', active ? '…' : runDuration(run.started_at, run.finished_at)],
+            ['Exit code', run.exit_code === null ? '—' : String(run.exit_code)],
+            ['Warnings', String(run.stats?.warn_count ?? 0)],
+            ['Errors', String(run.stats?.error_count ?? 0)],
+          ].map(([label, value]) => (
+            <div key={label}>
+              <dt className="text-xs uppercase tracking-wide text-ink-muted">{label}</dt>
+              <dd className="mt-0.5 text-ink-secondary">{value}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+
+      {sources.length > 0 && (
+        <div className="overflow-x-auto rounded-lg border border-edge bg-surface">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-edge text-left text-xs uppercase tracking-wide text-ink-muted">
+                <th className="px-4 py-2 font-medium">Source</th>
+                <th className="px-4 py-2 font-medium">Type</th>
+                <th className="px-4 py-2 font-medium">Version</th>
+                <th className="px-4 py-2 font-medium">Duration</th>
+                <th className="px-4 py-2 font-medium">Result</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sources.map(source => (
+                <tr key={`${source.product_name}-${source.type}`} className="border-b border-edge/60 last:border-0">
+                  <td className="px-4 py-2 font-medium">{source.product_name}</td>
+                  <td className="px-4 py-2 text-ink-secondary">{source.type}</td>
+                  <td className="px-4 py-2 text-ink-secondary">{source.version}</td>
+                  <td className="px-4 py-2 text-ink-secondary">{formatDuration(source.duration_ms / 1000)}</td>
+                  <td className="px-4 py-2">
+                    {source.ok ? (
+                      <span className="text-good-text">✓ ok</span>
+                    ) : (
+                      <span className="text-critical" title={source.error}>✕ {source.error ?? 'failed'}</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div>
+        <h2 className="mb-2 text-sm font-semibold text-ink-secondary">Logs</h2>
+        <LogViewer runId={runId} isActive={active} />
+      </div>
+    </div>
+  );
+}

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  build: {
+    outDir: '../dist/ui',
+    emptyOutDir: true,
+    sourcemap: false,
+  },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Overview

Adds a long-running **controller mode** to doc2vec alongside the existing one-shot CLI, plus a React web UI for managing configs, triggering/monitoring runs, and viewing logs.

## What's included

- **Controller mode** (`12ebe90`) — scheduler, Postgres persistence for configs/runs, and a web UI. Runs sources on a schedule, persists run history, and exposes an event bus for run lifecycle updates.
- **Crawler robustness** (`75260f5`) — abort a crawl when the browser can't launch (instead of silently producing an empty result), and write the `404.yaml` report to a writable dir.
- **Log UX** (`70b3485`) — log level + keyword filters in the UI; memory diagnostics logged on browser-launch failure.
- **Browser fix** (`92fc4bf`) — use Puppeteer's Chrome for Testing; Debian's chromium 150 crashes in containers.
- **Log follow-mode** (`637f883`) — keep follow-mode stable during heavy log bursts (programmatic scrolls no longer disable follow; only user scrolling does).
- **Slack notifications** (`6eba7e2`) — post to a Slack webhook when a run reaches a terminal status (succeeded / failed / canceled), with an optional "view run" link.

## Notes

- New `ui/` React app (Vite) with its own package.json / tsconfig.
- All commits are DCO signed-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)