### PR TITLE
feat(controller): per-source run stats and chunk lookup page

### DIFF
--- a/controller/chunk-inspector.ts
+++ b/controller/chunk-inspector.ts
@@ -1,0 +1,208 @@
+import BetterSqlite3 from 'better-sqlite3';
+import * as path from 'path';
+import * as sqliteVec from 'sqlite-vec';
+import * as yaml from 'js-yaml';
+import { QdrantClient } from '@qdrant/js-client-rest';
+import { NotFoundError, ValidationError } from './types';
+
+const MAX_CHUNKS = 500;
+
+export interface ChunkRecord {
+    chunk_id: string;
+    url: string;
+    product_name: string | null;
+    version: string | null;
+    section: string | null;
+    heading_hierarchy: string[];
+    chunk_index: number | null;
+    total_chunks: number | null;
+    hash: string | null;
+    created_at: string | null;
+    content: string;
+}
+
+export interface ChunkLookupResult {
+    source: { product_name: string; type: string; version: string };
+    database: { type: 'sqlite'; path: string } | { type: 'qdrant'; url: string; collection: string };
+    chunks: ChunkRecord[];
+}
+
+export interface SourceSelector {
+    product_name: string;
+    type?: string;
+    version?: string;
+}
+
+/**
+ * Read-only lookup of the chunks stored for a URL in a source's vector store.
+ * Resolves the store the same way a sync job would (same defaults as
+ * DatabaseManager.initDatabase, same ${ENV_VAR} substitution as Doc2Vec's
+ * config loader), but never creates tables or collections.
+ */
+export async function lookupChunks(configContent: string, selector: SourceSelector, url: string): Promise<ChunkLookupResult> {
+    const source = findSource(configContent, selector);
+    const dbConfig = source.database_config ?? {};
+    const params = dbConfig.params ?? {};
+
+    if (dbConfig.type === 'sqlite') {
+        const dbPath = params.db_path
+            || path.join(process.cwd(), `${String(source.product_name).replace(/\s+/g, '_')}-${source.version}.db`);
+        return {
+            source: { product_name: source.product_name, type: source.type, version: source.version },
+            database: { type: 'sqlite', path: dbPath },
+            chunks: lookupSqlite(dbPath, url),
+        };
+    }
+
+    if (dbConfig.type === 'qdrant') {
+        const qdrantUrl = params.qdrant_url || 'http://localhost:6333';
+        const qdrantPort = params.qdrant_port || 443;
+        const collectionName = params.collection_name
+            || `${String(source.product_name).toLowerCase().replace(/\s+/g, '_')}_${source.version}`;
+        const client = new QdrantClient({ url: qdrantUrl, apiKey: process.env.QDRANT_API_KEY, port: qdrantPort });
+        return {
+            source: { product_name: source.product_name, type: source.type, version: source.version },
+            database: { type: 'qdrant', url: qdrantUrl, collection: collectionName },
+            chunks: await lookupQdrant(client, collectionName, url),
+        };
+    }
+
+    throw new ValidationError(`source has unsupported database type: ${dbConfig.type}`);
+}
+
+function findSource(configContent: string, selector: SourceSelector): any {
+    // Same ${VAR} substitution the sync job applies when it loads the config
+    const substituted = configContent.replace(/\$\{([^}]+)\}/g, (match, varName) =>
+        process.env[varName] !== undefined ? process.env[varName]! : match
+    );
+
+    let parsed: any;
+    try {
+        parsed = yaml.load(substituted);
+    } catch (err) {
+        throw new ValidationError(`config does not parse: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    const sources: any[] = Array.isArray(parsed?.sources) ? parsed.sources : [];
+    const source = sources.find(s =>
+        s?.product_name === selector.product_name
+        && (selector.type === undefined || s?.type === selector.type)
+        && (selector.version === undefined || String(effectiveVersion(s)) === selector.version)
+    );
+    if (!source) {
+        throw new NotFoundError(`source '${selector.product_name}' not found in config`);
+    }
+    return { ...source, version: effectiveVersion(source) };
+}
+
+// Mirrors the version defaulting in Doc2Vec.loadConfig for code sources
+function effectiveVersion(source: any): string {
+    if (source?.version && String(source.version).trim().length > 0) return String(source.version);
+    if (source?.type === 'code') {
+        if (source.branch && String(source.branch).trim().length > 0) return String(source.branch);
+        return 'local';
+    }
+    return String(source?.version ?? '');
+}
+
+function lookupSqlite(dbPath: string, url: string): ChunkRecord[] {
+    let db: BetterSqlite3.Database;
+    try {
+        db = new BetterSqlite3(dbPath, { readonly: true, fileMustExist: true, allowExtension: true } as any);
+    } catch {
+        throw new NotFoundError(`SQLite database not found at ${dbPath} (has this source ever been synced?)`);
+    }
+
+    try {
+        sqliteVec.load(db);
+        const hasDates = db
+            .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'vec_chunk_dates'`)
+            .get() !== undefined;
+        const rows = db.prepare(`
+            SELECT v.chunk_id, v.url, v.product_name, v.version, v.section, v.heading_hierarchy,
+                   v.chunk_index, v.total_chunks, v.hash, v.content
+                   ${hasDates ? ', d.created_at AS created_at' : ', NULL AS created_at'}
+            FROM vec_items v
+            ${hasDates ? 'LEFT JOIN vec_chunk_dates d ON d.chunk_id = v.chunk_id' : ''}
+            WHERE v.url = ?
+            LIMIT ${MAX_CHUNKS}
+        `).all(url) as any[];
+
+        return sortChunks(rows.map(row => ({
+            chunk_id: String(row.chunk_id),
+            url: String(row.url),
+            product_name: row.product_name ?? null,
+            version: row.version ?? null,
+            section: row.section ?? null,
+            heading_hierarchy: parseHierarchy(row.heading_hierarchy),
+            chunk_index: row.chunk_index === null || row.chunk_index === undefined ? null : Number(row.chunk_index),
+            total_chunks: row.total_chunks === null || row.total_chunks === undefined ? null : Number(row.total_chunks),
+            hash: row.hash ?? null,
+            created_at: row.created_at ?? null,
+            content: String(row.content ?? ''),
+        })));
+    } finally {
+        db.close();
+    }
+}
+
+async function lookupQdrant(client: QdrantClient, collectionName: string, url: string): Promise<ChunkRecord[]> {
+    const chunks: ChunkRecord[] = [];
+    let offset: any = undefined;
+    do {
+        const response = await client.scroll(collectionName, {
+            limit: 200,
+            offset,
+            with_payload: true,
+            with_vector: false,
+            filter: {
+                must: [{ key: 'url', match: { value: url } }],
+                must_not: [{ key: 'is_metadata', match: { value: true } }],
+            },
+        });
+        for (const point of response.points) {
+            const p: any = point.payload ?? {};
+            chunks.push({
+                chunk_id: String(p.original_chunk_id ?? point.id),
+                url: String(p.url ?? url),
+                product_name: p.product_name ?? null,
+                version: p.version ?? null,
+                section: p.section ?? null,
+                heading_hierarchy: parseHierarchy(p.heading_hierarchy),
+                chunk_index: p.chunk_index === null || p.chunk_index === undefined ? null : Number(p.chunk_index),
+                total_chunks: p.total_chunks === null || p.total_chunks === undefined ? null : Number(p.total_chunks),
+                hash: p.hash ?? null,
+                created_at: p.created_at ?? null,
+                content: String(p.content ?? ''),
+            });
+            if (chunks.length >= MAX_CHUNKS) return sortChunks(chunks);
+        }
+        offset = response.next_page_offset;
+    } while (offset !== null && offset !== undefined);
+
+    return sortChunks(chunks);
+}
+
+function parseHierarchy(value: unknown): string[] {
+    if (Array.isArray(value)) return value.map(String);
+    if (typeof value === 'string' && value.trim().startsWith('[')) {
+        try {
+            const parsed = JSON.parse(value);
+            if (Array.isArray(parsed)) return parsed.map(String);
+        } catch { /* fall through */ }
+    }
+    return value ? [String(value)] : [];
+}
+
+// Newest first; chunks without a creation date (stored before this feature) sink
+// to the bottom, ordered by their position in the page.
+function sortChunks(chunks: ChunkRecord[]): ChunkRecord[] {
+    return chunks.sort((a, b) => {
+        if (a.created_at && b.created_at && a.created_at !== b.created_at) {
+            return a.created_at < b.created_at ? 1 : -1;
+        }
+        if (a.created_at && !b.created_at) return -1;
+        if (!a.created_at && b.created_at) return 1;
+        return (a.chunk_index ?? 0) - (b.chunk_index ?? 0);
+    });
+}

--- a/controller/chunk-inspector.ts
+++ b/controller/chunk-inspector.ts
@@ -194,15 +194,13 @@ function parseHierarchy(value: unknown): string[] {
     return value ? [String(value)] : [];
 }
 
-// Newest first; chunks without a creation date (stored before this feature) sink
-// to the bottom, ordered by their position in the page.
+// Default order: position within the page. The UI offers per-column sorting
+// (including by creation date) on top of this.
 function sortChunks(chunks: ChunkRecord[]): ChunkRecord[] {
     return chunks.sort((a, b) => {
-        if (a.created_at && b.created_at && a.created_at !== b.created_at) {
-            return a.created_at < b.created_at ? 1 : -1;
-        }
-        if (a.created_at && !b.created_at) return -1;
-        if (!a.created_at && b.created_at) return 1;
-        return (a.chunk_index ?? 0) - (b.chunk_index ?? 0);
+        const ai = a.chunk_index ?? Number.MAX_SAFE_INTEGER;
+        const bi = b.chunk_index ?? Number.MAX_SAFE_INTEGER;
+        if (ai !== bi) return ai - bi;
+        return a.chunk_id.localeCompare(b.chunk_id);
     });
 }

--- a/controller/server.ts
+++ b/controller/server.ts
@@ -2,6 +2,7 @@ import express, { NextFunction, Request, Response } from 'express';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Logger } from '../logger';
+import { lookupChunks } from './chunk-inspector';
 import { ConfigRegistry, isValidCron, parseConfigMeta } from './config-registry';
 import { ControllerEvents } from './events';
 import { JobRunner } from './job-runner';
@@ -140,6 +141,31 @@ export function createServer(deps: ServerDeps): express.Express {
         if (!registry.get(id)) throw new NotFoundError('config not found');
         const days = Number(req.query.days) || 30;
         res.json(await store.getConfigStats(id, days));
+    });
+
+    // Inspect the chunks currently stored for a URL in one source's vector store.
+    // This reads the live store, so results reflect the present state, not a
+    // historical run.
+    app.get('/api/configs/:id/chunks', async (req, res) => {
+        const config = registry.get(parseId(String(req.params.id)));
+        if (!config) throw new NotFoundError('config not found');
+        const url = typeof req.query.url === 'string' ? req.query.url.trim() : '';
+        const productName = typeof req.query.product_name === 'string' ? req.query.product_name : '';
+        if (!url) throw new ValidationError('url query parameter is required');
+        if (!productName) throw new ValidationError('product_name query parameter is required');
+
+        try {
+            res.json(await lookupChunks(config.content, {
+                product_name: productName,
+                type: typeof req.query.type === 'string' && req.query.type ? req.query.type : undefined,
+                version: typeof req.query.version === 'string' && req.query.version ? req.query.version : undefined,
+            }, url));
+        } catch (err) {
+            if (err instanceof NotFoundError || err instanceof ValidationError) throw err;
+            // Vector store unreachable (e.g. Qdrant down) — surface the reason
+            logger.error('Chunk lookup failed:', err);
+            res.status(502).json({ error: `chunk lookup failed: ${err instanceof Error ? err.message : String(err)}` });
+        }
     });
 
     // ------------------------------------------------------------------ runs

--- a/controller/types.ts
+++ b/controller/types.ts
@@ -53,6 +53,16 @@ export interface RunRecord {
     finished_at: string | null;
 }
 
+export interface SourceRunCounters {
+    items_kind: string;
+    items_new: number;
+    items_updated: number;
+    items_unchanged: number;
+    items_deleted: number;
+    chunks_added: number;
+    chunks_deleted: number;
+}
+
 export interface RunStatsPayload {
     sources?: Array<{
         product_name: string;
@@ -61,6 +71,7 @@ export interface RunStatsPayload {
         duration_ms: number;
         ok: boolean;
         error?: string;
+        counters?: SourceRunCounters;
     }>;
     warn_count?: number;
     error_count?: number;

--- a/database.ts
+++ b/database.ts
@@ -50,6 +50,7 @@ export class DatabaseManager {
                     total_chunks INTEGER
                 );
             `);
+            this.ensureChunkDatesTable(db);
             logger.info(`SQLite database initialized successfully`);
             return { db, type: 'sqlite' };
         } else if (dbConfig.type === 'qdrant') {
@@ -320,9 +321,25 @@ export class DatabaseManager {
         }
     }
 
+    /**
+     * Chunk creation timestamps live in a companion table because vec_items is
+     * a vec0 virtual table that cannot be ALTERed to add a column. Rows are
+     * written on every chunk insert/update; stale rows for deleted chunks are
+     * harmless (lookups always join against vec_items).
+     */
+    static ensureChunkDatesTable(db: Database): void {
+        db.exec(`
+            CREATE TABLE IF NOT EXISTS vec_chunk_dates (
+                chunk_id   TEXT PRIMARY KEY,
+                created_at TEXT NOT NULL
+            );
+        `);
+    }
+
     static prepareSQLiteStatements(db: Database) {
         let cached = this.columnCache.get(db);
         if (!cached) {
+            this.ensureChunkDatesTable(db);
             cached = {
                 hasBranch: this.hasColumn(db, 'branch'),
                 hasRepo: this.hasColumn(db, 'repo')
@@ -374,15 +391,19 @@ export class DatabaseManager {
             `),
             getAllChunkIdsStmt: db.prepare(`SELECT chunk_id FROM vec_items`),
             deleteChunkStmt: db.prepare(`DELETE FROM vec_items WHERE chunk_id = ?`),
+            touchDateStmt: db.prepare(`
+                INSERT INTO vec_chunk_dates (chunk_id, created_at) VALUES (?, ?)
+                ON CONFLICT(chunk_id) DO UPDATE SET created_at = excluded.created_at
+            `),
             hasBranchColumn,
             hasRepoColumn
         };
     }
 
     static insertVectorsSQLite(db: Database, chunk: DocumentChunk, embedding: number[], logger: Logger, chunkHash?: string) {
-        const { insertStmt, updateStmt, hasBranchColumn, hasRepoColumn } = this.prepareSQLiteStatements(db);
+        const { insertStmt, updateStmt, touchDateStmt, hasBranchColumn, hasRepoColumn } = this.prepareSQLiteStatements(db);
         const hash = chunkHash || Utils.generateHash(chunk.content);
-        
+
         const transaction = db.transaction(() => {
             // Use BigInt for true integer representation in SQLite vec0
             const chunkIndex = BigInt(chunk.metadata.chunk_index | 0);
@@ -443,6 +464,8 @@ export class DatabaseManager {
 
                 updateStmt.run(...updateValues);
             }
+
+            touchDateStmt.run(chunk.metadata.chunk_id, new Date().toISOString());
         });
 
         transaction();
@@ -479,6 +502,7 @@ export class DatabaseManager {
                     original_chunk_id: chunk.metadata.chunk_id,
                     chunk_index: chunk.metadata.chunk_index,
                     total_chunks: chunk.metadata.total_chunks,
+                    created_at: new Date().toISOString(),
                 },
             };
 
@@ -495,7 +519,7 @@ export class DatabaseManager {
         }
     }
 
-    static removeObsoleteChunksSQLite(db: Database, visitedUrls: Set<string>, urlPrefix: string, logger: Logger) {
+    static removeObsoleteChunksSQLite(db: Database, visitedUrls: Set<string>, urlPrefix: string, logger: Logger): { items: number; chunks: number } {
         const getChunksForUrlStmt = db.prepare(`
             SELECT chunk_id, url FROM vec_items
             WHERE url LIKE ? || '%'
@@ -504,6 +528,7 @@ export class DatabaseManager {
 
         const existingChunks = getChunksForUrlStmt.all(urlPrefix) as { chunk_id: string; url: string }[];
         let deletedCount = 0;
+        const deletedUrls = new Set<string>();
 
         const transaction = db.transaction(() => {
             for (const { chunk_id, url } of existingChunks) {
@@ -511,15 +536,17 @@ export class DatabaseManager {
                     logger.debug(`Deleting obsolete chunk from SQLite: ${chunk_id.substring(0, 8)}... (URL not visited)`);
                     deleteChunkStmt.run(chunk_id);
                     deletedCount++;
+                    deletedUrls.add(url);
                 }
             }
         });
         transaction();
 
         logger.info(`Deleted ${deletedCount} obsolete chunks from SQLite for URL ${urlPrefix}`);
+        return { items: deletedUrls.size, chunks: deletedCount };
     }
 
-    static async removeObsoleteChunksQdrant(db: QdrantDB, visitedUrls: Set<string>, urlPrefix: string, logger: Logger) {
+    static async removeObsoleteChunksQdrant(db: QdrantDB, visitedUrls: Set<string>, urlPrefix: string, logger: Logger): Promise<{ items: number; chunks: number }> {
         const { client, collectionName } = db;
         try {
             // Scroll through ALL points that match the URL prefix but are not
@@ -547,6 +574,7 @@ export class DatabaseManager {
             };
 
             const obsoletePointIds: any[] = [];
+            const obsoleteUrls = new Set<string>();
             let offset: any = undefined;
             do {
                 const response = await client.scroll(collectionName, {
@@ -565,6 +593,7 @@ export class DatabaseManager {
                     }
                     if (url && !visitedUrls.has(url)) {
                         obsoletePointIds.push(point.id);
+                        obsoleteUrls.add(url);
                     }
                 }
 
@@ -579,6 +608,7 @@ export class DatabaseManager {
             } else {
                 logger.info(`No obsolete chunks to delete from Qdrant for URL ${urlPrefix}`);
             }
+            return { items: obsoleteUrls.size, chunks: obsoletePointIds.length };
         } catch (error) {
             // Rethrow so a failed cleanup fails the job instead of silently
             // leaving orphans behind. This is idempotent and recomputed each
@@ -597,36 +627,46 @@ export class DatabaseManager {
         }
     }
 
-    static removeChunksByUrlSQLite(db: Database, url: string, logger: Logger) {
+    static removeChunksByUrlSQLite(db: Database, url: string, logger: Logger): number {
         const deleteStmt = db.prepare(`DELETE FROM vec_items WHERE url = ?`);
         const result = deleteStmt.run(url);
         logger.info(`Deleted ${result.changes} chunks from SQLite for URL ${url}`);
+        return result.changes;
     }
 
-    static async removeChunksByUrlQdrant(db: QdrantDB, url: string, logger: Logger) {
+    static async removeChunksByUrlQdrant(db: QdrantDB, url: string, logger: Logger): Promise<number> {
         const { client, collectionName } = db;
         try {
-            await client.delete(collectionName, {
-                filter: {
-                    must: [
-                        {
-                            key: 'url',
-                            match: {
-                                value: url  // Exact match — must match getChunkHashesByUrlQdrant's filter
-                            }
+            const filter = {
+                must: [
+                    {
+                        key: 'url',
+                        match: {
+                            value: url  // Exact match — must match getChunkHashesByUrlQdrant's filter
                         }
-                    ],
-                    must_not: [
-                        {
-                            key: 'is_metadata',
-                            match: {
-                                value: true
-                            }
+                    }
+                ],
+                must_not: [
+                    {
+                        key: 'is_metadata',
+                        match: {
+                            value: true
                         }
-                    ]
-                }
-            });
+                    }
+                ]
+            };
+            // Count first so callers can report how many chunks the delete removed
+            // (Qdrant's delete-by-filter response doesn't include a count).
+            let deletedCount = 0;
+            try {
+                const countResult = await client.count(collectionName, { filter, exact: true });
+                deletedCount = countResult?.count ?? 0;
+            } catch {
+                // Count is informational only — never fail the delete over it
+            }
+            await client.delete(collectionName, { filter });
             logger.info(`Deleted chunks from Qdrant for URL ${url}`);
+            return deletedCount;
         } catch (error) {
             // Rethrow so the failure propagates and the job exits non-zero.
             // A swallowed delete leaves stale chunks behind while the sync
@@ -730,11 +770,11 @@ export class DatabaseManager {
     }
 
     static removeObsoleteFilesSQLite(
-        db: Database, 
-        processedFiles: Set<string>, 
-        pathConfig: { path: string; url_rewrite_prefix?: string } | string, 
+        db: Database,
+        processedFiles: Set<string>,
+        pathConfig: { path: string; url_rewrite_prefix?: string } | string,
         logger: Logger
-    ) {
+    ): { items: number; chunks: number } {
         const getChunksForPathStmt = db.prepare(`
             SELECT chunk_id, url FROM vec_items
             WHERE url LIKE ? || '%'
@@ -760,7 +800,8 @@ export class DatabaseManager {
         logger.debug(`Searching for chunks with URL prefix: ${urlPrefix}`);
         const existingChunks = getChunksForPathStmt.all(urlPrefix) as { chunk_id: string; url: string }[];
         let deletedCount = 0;
-        
+        const deletedUrls = new Set<string>();
+
         const transaction = db.transaction(() => {
             for (const { chunk_id, url } of existingChunks) {
                 // Skip if it's not from our URL prefix (safety check)
@@ -785,20 +826,22 @@ export class DatabaseManager {
                     logger.debug(`Deleting obsolete chunk from SQLite: ${chunk_id.substring(0, 8)}... (File not processed: ${filePath})`);
                     deleteChunkStmt.run(chunk_id);
                     deletedCount++;
+                    deletedUrls.add(url);
                 }
             }
         });
         transaction();
-        
+
         logger.info(`Deleted ${deletedCount} obsolete chunks from SQLite for URL prefix ${urlPrefix}`);
+        return { items: deletedUrls.size, chunks: deletedCount };
     }
 
     static async removeObsoleteFilesQdrant(
-        db: QdrantDB, 
-        processedFiles: Set<string>, 
-        pathConfig: { path: string; url_rewrite_prefix?: string } | string, 
+        db: QdrantDB,
+        processedFiles: Set<string>,
+        pathConfig: { path: string; url_rewrite_prefix?: string } | string,
         logger: Logger
-    ) {
+    ): Promise<{ items: number; chunks: number }> {
         const { client, collectionName } = db;
         try {
             // Determine if we're using URL rewriting or direct file paths
@@ -843,6 +886,7 @@ export class DatabaseManager {
             };
 
             const obsoletePointIds: any[] = [];
+            const obsoleteUrls = new Set<string>();
             let offset: any = undefined;
             do {
                 const response = await client.scroll(collectionName, {
@@ -878,6 +922,7 @@ export class DatabaseManager {
 
                     if (filePath && !processedFiles.has(filePath)) {
                         obsoletePointIds.push(point.id);
+                        obsoleteUrls.add(url);
                     }
                 }
 
@@ -892,6 +937,7 @@ export class DatabaseManager {
             } else {
                 logger.info(`No obsolete chunks to delete from Qdrant for URL prefix ${urlPrefix}`);
             }
+            return { items: obsoleteUrls.size, chunks: obsoletePointIds.length };
         } catch (error) {
             // Rethrow so a failed cleanup fails the job instead of silently
             // leaving orphans behind (idempotent — retried cleanly next run).

--- a/doc2vec.ts
+++ b/doc2vec.ts
@@ -29,7 +29,9 @@ import {
     BrokenLink,
     EmbeddingConfig,
     MarkdownStoreConfig,
-    SourceRunStats
+    SourceRunStats,
+    SourceRunCounters,
+    newSourceRunCounters
 } from './types';
 import { S3Client, ListObjectsV2Command, GetObjectCommand } from '@aws-sdk/client-s3';
 import { MarkdownStore } from './markdown-store';
@@ -49,6 +51,9 @@ export class Doc2Vec {
     private configDir: string;
     private brokenLinksByWebsite: Record<string, BrokenLink[]> = {};
     private markdownStore: MarkdownStore | undefined;
+    // Change counters for the source currently being processed by run().
+    // Sources are processed sequentially, so a single slot is sufficient.
+    private counters: SourceRunCounters = newSourceRunCounters('items');
 
     constructor(configPath: string) {
         this.logger = new Logger('Doc2Vec', {
@@ -194,6 +199,16 @@ export class Doc2Vec {
             let ok = true;
             let errorMessage: string | undefined;
 
+            const itemsKindByType: Record<string, string> = {
+                website: 'pages',
+                github: 'issues',
+                local_directory: 'files',
+                code: 'files',
+                s3: 'objects',
+                zendesk: 'items',
+            };
+            this.counters = newSourceRunCounters(itemsKindByType[sourceConfig.type] ?? 'items');
+
             try {
                 if (sourceConfig.type === 'github') {
                     await this.processGithubRepo(sourceConfig, sourceLogger);
@@ -224,7 +239,8 @@ export class Doc2Vec {
                 version: sourceConfig.version,
                 duration_ms: Date.now() - startTime,
                 ok,
-                ...(errorMessage && { error: errorMessage })
+                ...(errorMessage && { error: errorMessage }),
+                counters: this.counters
             });
         }
 
@@ -406,10 +422,17 @@ export class Doc2Vec {
             // ones would otherwise linger — leaving stale state ("open") and missing
             // the latest comments in search results. All chunks for an issue share
             // its unique url, so delete-by-url reconciles them exactly.
+            let removedChunks = 0;
             if (dbConnection.type === 'sqlite') {
-                DatabaseManager.removeChunksByUrlSQLite(dbConnection.db, url, logger);
+                removedChunks = DatabaseManager.removeChunksByUrlSQLite(dbConnection.db, url, logger);
             } else if (dbConnection.type === 'qdrant') {
-                await DatabaseManager.removeChunksByUrlQdrant(dbConnection, url, logger);
+                removedChunks = await DatabaseManager.removeChunksByUrlQdrant(dbConnection, url, logger);
+            }
+            if (removedChunks > 0) {
+                this.counters.items_updated++;
+                this.counters.chunks_deleted += removedChunks;
+            } else {
+                this.counters.items_new++;
             }
 
             // Process and store each chunk immediately
@@ -429,6 +452,7 @@ export class Doc2Vec {
                     const embeddings = await this.createEmbeddings([chunk.content]);
                     if (embeddings.length) {
                         DatabaseManager.insertVectorsSQLite(dbConnection.db, chunk, embeddings[0], logger, chunkHash);
+                        this.counters.chunks_added++;
                         logger.debug(`Stored chunk ${chunkId} in SQLite`);
                     } else {
                         logger.error(`Embedding failed for chunk: ${chunkId}`);
@@ -459,6 +483,7 @@ export class Doc2Vec {
                         const embeddings = await this.createEmbeddings([chunk.content]);
                         if (embeddings.length) {
                             await DatabaseManager.storeChunkInQdrant(dbConnection, chunk, embeddings[0], chunkHash);
+                            this.counters.chunks_added++;
                             logger.debug(`Stored chunk ${chunkId} in Qdrant (${dbConnection.collectionName})`);
                         } else {
                             logger.error(`Embedding failed for chunk: ${chunkId}`);
@@ -631,10 +656,15 @@ export class Doc2Vec {
                 }
                 // Vector DB chunks
                 try {
+                    let removedChunks = 0;
                     if (dbConnection.type === 'sqlite') {
-                        DatabaseManager.removeChunksByUrlSQLite(dbConnection.db, url, logger);
+                        removedChunks = DatabaseManager.removeChunksByUrlSQLite(dbConnection.db, url, logger);
                     } else if (dbConnection.type === 'qdrant') {
-                        await DatabaseManager.removeChunksByUrlQdrant(dbConnection, url, logger);
+                        removedChunks = await DatabaseManager.removeChunksByUrlQdrant(dbConnection, url, logger);
+                    }
+                    if (removedChunks > 0) {
+                        this.counters.items_deleted++;
+                        this.counters.chunks_deleted += removedChunks;
                     }
                 } catch (dbError) {
                     logger.error(`Failed to delete chunks for 404 URL ${url}:`, dbError);
@@ -653,13 +683,16 @@ export class Doc2Vec {
                 await DatabaseManager.setMetadataValue(dbConnection, syncCompleteKey, 'true', logger, this.embeddingDimension);
                 logger.info('Full sync completed successfully — subsequent runs will use normal caching');
             }
+            let removed = { items: 0, chunks: 0 };
             if (dbConnection.type === 'sqlite') {
                 logger.info(`Running SQLite cleanup for ${urlPrefix}`);
-                DatabaseManager.removeObsoleteChunksSQLite(dbConnection.db, visitedUrls, urlPrefix, logger);
+                removed = DatabaseManager.removeObsoleteChunksSQLite(dbConnection.db, visitedUrls, urlPrefix, logger);
             } else if (dbConnection.type === 'qdrant') {
                 logger.info(`Running Qdrant cleanup for ${urlPrefix} in collection ${dbConnection.collectionName}`);
-                await DatabaseManager.removeObsoleteChunksQdrant(dbConnection, visitedUrls, urlPrefix, logger);
+                removed = await DatabaseManager.removeObsoleteChunksQdrant(dbConnection, visitedUrls, urlPrefix, logger);
             }
+            this.counters.items_deleted += removed.items;
+            this.counters.chunks_deleted += removed.chunks;
         }
 
         logger.info(`Finished processing website: ${config.url}`);
@@ -763,14 +796,17 @@ export class Doc2Vec {
         );
         
         logger.section('CLEANUP');
+        let removed = { items: 0, chunks: 0 };
         if (dbConnection.type === 'sqlite') {
             logger.info(`Running SQLite cleanup for local directory ${config.path}`);
-            DatabaseManager.removeObsoleteFilesSQLite(dbConnection.db, processedFiles, config, logger);
+            removed = DatabaseManager.removeObsoleteFilesSQLite(dbConnection.db, processedFiles, config, logger);
         } else if (dbConnection.type === 'qdrant') {
             logger.info(`Running Qdrant cleanup for local directory ${config.path} in collection ${dbConnection.collectionName}`);
-            await DatabaseManager.removeObsoleteFilesQdrant(dbConnection, processedFiles, config, logger);
+            removed = await DatabaseManager.removeObsoleteFilesQdrant(dbConnection, processedFiles, config, logger);
         }
-        
+        this.counters.items_deleted += removed.items;
+        this.counters.chunks_deleted += removed.chunks;
+
         logger.info(`Finished processing local directory: ${config.path}`);
     }
 
@@ -960,10 +996,15 @@ export class Doc2Vec {
                     fileUrl = `s3://${config.bucket}/${deletedKey}`;
                 }
 
+                let removedChunks = 0;
                 if (dbConnection.type === 'sqlite') {
-                    DatabaseManager.removeChunksByUrlSQLite(dbConnection.db, fileUrl, logger);
+                    removedChunks = DatabaseManager.removeChunksByUrlSQLite(dbConnection.db, fileUrl, logger);
                 } else if (dbConnection.type === 'qdrant') {
-                    await DatabaseManager.removeChunksByUrlQdrant(dbConnection, fileUrl, logger);
+                    removedChunks = await DatabaseManager.removeChunksByUrlQdrant(dbConnection, fileUrl, logger);
+                }
+                if (removedChunks > 0) {
+                    this.counters.items_deleted++;
+                    this.counters.chunks_deleted += removedChunks;
                 }
             }
         }
@@ -1124,10 +1165,15 @@ export class Doc2Vec {
                 if (deleteUrls.length > 0) {
                     logger.info(`Cleaning up ${deleteUrls.length} deleted/renamed files`);
                     for (const url of deleteUrls) {
+                        let removedChunks = 0;
                         if (dbConnection.type === 'sqlite') {
-                            DatabaseManager.removeChunksByUrlSQLite(dbConnection.db, url, logger);
+                            removedChunks = DatabaseManager.removeChunksByUrlSQLite(dbConnection.db, url, logger);
                         } else if (dbConnection.type === 'qdrant') {
-                            await DatabaseManager.removeChunksByUrlQdrant(dbConnection, url, logger);
+                            removedChunks = await DatabaseManager.removeChunksByUrlQdrant(dbConnection, url, logger);
+                        }
+                        if (removedChunks > 0) {
+                            this.counters.items_deleted++;
+                            this.counters.chunks_deleted += removedChunks;
                         }
                     }
                 } else {
@@ -1142,10 +1188,15 @@ export class Doc2Vec {
 
                     for (const deletedFile of deletedFiles) {
                         const url = this.buildCodeFileUrl(deletedFile, basePath as string, config, repoUrlPrefix);
+                        let removedChunks = 0;
                         if (dbConnection.type === 'sqlite') {
-                            DatabaseManager.removeChunksByUrlSQLite(dbConnection.db, url, logger);
+                            removedChunks = DatabaseManager.removeChunksByUrlSQLite(dbConnection.db, url, logger);
                         } else if (dbConnection.type === 'qdrant') {
-                            await DatabaseManager.removeChunksByUrlQdrant(dbConnection, url, logger);
+                            removedChunks = await DatabaseManager.removeChunksByUrlQdrant(dbConnection, url, logger);
+                        }
+                        if (removedChunks > 0) {
+                            this.counters.items_deleted++;
+                            this.counters.chunks_deleted += removedChunks;
                         }
                     }
 
@@ -1156,13 +1207,16 @@ export class Doc2Vec {
                     }
                 }
             } else {
+                let removed = { items: 0, chunks: 0 };
                 if (dbConnection.type === 'sqlite') {
                     logger.info(`Running SQLite cleanup for code source ${basePath}`);
-                    DatabaseManager.removeObsoleteFilesSQLite(dbConnection.db, processedFiles, cleanupPathConfig, logger);
+                    removed = DatabaseManager.removeObsoleteFilesSQLite(dbConnection.db, processedFiles, cleanupPathConfig, logger);
                 } else if (dbConnection.type === 'qdrant') {
                     logger.info(`Running Qdrant cleanup for code source ${basePath} in collection ${dbConnection.collectionName}`);
-                    await DatabaseManager.removeObsoleteFilesQdrant(dbConnection, processedFiles, cleanupPathConfig, logger);
+                    removed = await DatabaseManager.removeObsoleteFilesQdrant(dbConnection, processedFiles, cleanupPathConfig, logger);
                 }
+                this.counters.items_deleted += removed.items;
+                this.counters.chunks_deleted += removed.chunks;
             }
 
             if (config.source === 'github' && basePath && repoBranch) {
@@ -1475,10 +1529,15 @@ export class Doc2Vec {
             // Deleted tickets — remove their chunks and stop
             if (ticket.status === 'deleted') {
                 logger.info(`Ticket #${ticketId} was deleted in Zendesk — removing its chunks`);
+                let removedChunks = 0;
                 if (dbConnection.type === 'sqlite') {
-                    DatabaseManager.removeChunksByUrlSQLite(dbConnection.db, url, logger);
+                    removedChunks = DatabaseManager.removeChunksByUrlSQLite(dbConnection.db, url, logger);
                 } else {
-                    await DatabaseManager.removeChunksByUrlQdrant(dbConnection, url, logger);
+                    removedChunks = await DatabaseManager.removeChunksByUrlQdrant(dbConnection, url, logger);
+                }
+                if (removedChunks > 0) {
+                    this.counters.items_deleted++;
+                    this.counters.chunks_deleted += removedChunks;
                 }
                 return;
             }
@@ -1787,6 +1846,7 @@ export class Doc2Vec {
 
         if (unchanged) {
             logger.info(`Skipping unchanged URL (${chunks.length} chunks): ${url}`);
+            this.counters.items_unchanged++;
             return 0;
         }
 
@@ -1798,6 +1858,10 @@ export class Doc2Vec {
             } else {
                 await DatabaseManager.removeChunksByUrlQdrant(dbConnection, url, logger);
             }
+            this.counters.items_updated++;
+            this.counters.chunks_deleted += existingHashesSorted.length;
+        } else {
+            this.counters.items_new++;
         }
 
         // 5. Embed and insert all new chunks
@@ -1827,6 +1891,7 @@ export class Doc2Vec {
         }
 
         chunkProgress.complete();
+        this.counters.chunks_added += embeddedCount;
         return embeddedCount;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "doc2vec",
-    "version": "2.10.5",
+    "version": "2.12.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "doc2vec",
-            "version": "2.10.5",
+            "version": "2.12.0",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.1004.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "doc2vec",
-    "version": "2.11.0",
+    "version": "2.12.0",
     "type": "commonjs",
     "description": "",
     "main": "dist/doc2vec.js",

--- a/tests/controller-chunk-inspector.test.ts
+++ b/tests/controller-chunk-inspector.test.ts
@@ -89,14 +89,14 @@ afterEach(() => {
 });
 
 describe('lookupChunks (sqlite)', () => {
-    it('returns the chunks stored for a URL, newest first, with content and metadata', async () => {
+    it('returns the chunks stored for a URL in page order, with creation dates and content', async () => {
         const db = createDbFile();
         const embedding = [0.1, 0.2, 0.3, 0.4];
-        DatabaseManager.insertVectorsSQLite(db, makeChunk({ chunk_id: 'chunk-old', content: 'Old chunk', chunk_index: 0, total_chunks: 2 }), embedding, testLogger);
-        DatabaseManager.insertVectorsSQLite(db, makeChunk({ chunk_id: 'chunk-new', content: 'New chunk', chunk_index: 1, total_chunks: 2 }), embedding, testLogger);
-        // Force distinct creation dates so ordering is deterministic
-        db.prepare(`UPDATE vec_chunk_dates SET created_at = ? WHERE chunk_id = ?`).run('2026-01-01T00:00:00.000Z', 'chunk-old');
-        db.prepare(`UPDATE vec_chunk_dates SET created_at = ? WHERE chunk_id = ?`).run('2026-06-01T00:00:00.000Z', 'chunk-new');
+        // Insert out of page order to prove the result is sorted by position
+        DatabaseManager.insertVectorsSQLite(db, makeChunk({ chunk_id: 'chunk-second', content: 'Second chunk', chunk_index: 1, total_chunks: 2 }), embedding, testLogger);
+        DatabaseManager.insertVectorsSQLite(db, makeChunk({ chunk_id: 'chunk-first', content: 'First chunk', chunk_index: 0, total_chunks: 2 }), embedding, testLogger);
+        db.prepare(`UPDATE vec_chunk_dates SET created_at = ? WHERE chunk_id = ?`).run('2026-01-01T00:00:00.000Z', 'chunk-first');
+        db.prepare(`UPDATE vec_chunk_dates SET created_at = ? WHERE chunk_id = ?`).run('2026-06-01T00:00:00.000Z', 'chunk-second');
         db.close();
 
         const result = await lookupChunks(
@@ -108,11 +108,12 @@ describe('lookupChunks (sqlite)', () => {
         expect(result.database).toEqual({ type: 'sqlite', path: dbPath });
         expect(result.source).toEqual({ product_name: 'TestSite', type: 'website', version: '1.0' });
         expect(result.chunks).toHaveLength(2);
-        expect(result.chunks[0].chunk_id).toBe('chunk-new');
-        expect(result.chunks[0].created_at).toBe('2026-06-01T00:00:00.000Z');
-        expect(result.chunks[0].content).toBe('New chunk');
+        expect(result.chunks[0].chunk_id).toBe('chunk-first');
+        expect(result.chunks[0].created_at).toBe('2026-01-01T00:00:00.000Z');
+        expect(result.chunks[0].content).toBe('First chunk');
         expect(result.chunks[0].heading_hierarchy).toEqual(['Guide', 'Install']);
-        expect(result.chunks[1].chunk_id).toBe('chunk-old');
+        expect(result.chunks[1].chunk_id).toBe('chunk-second');
+        expect(result.chunks[1].created_at).toBe('2026-06-01T00:00:00.000Z');
     });
 
     it('returns an empty list for a URL with no chunks', async () => {

--- a/tests/controller-chunk-inspector.test.ts
+++ b/tests/controller-chunk-inspector.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import BetterSqlite3 from 'better-sqlite3';
+import * as sqliteVec from 'sqlite-vec';
+import { lookupChunks } from '../controller/chunk-inspector';
+import { NotFoundError } from '../controller/types';
+import { DatabaseManager } from '../database';
+import { DocumentChunk } from '../types';
+import { Logger, LogLevel } from '../logger';
+
+const testLogger = new Logger('chunk-inspector-test', { level: LogLevel.NONE });
+const DIMENSION = 4;
+
+let tmpDir: string;
+let dbPath: string;
+
+function createDbFile(withDatesTable = true): BetterSqlite3.Database {
+    const db = new BetterSqlite3(dbPath, { allowExtension: true } as any);
+    sqliteVec.load(db);
+    db.exec(`
+        CREATE VIRTUAL TABLE IF NOT EXISTS vec_items USING vec0(
+            embedding FLOAT[${DIMENSION}],
+            product_name TEXT,
+            version TEXT,
+            branch TEXT,
+            repo TEXT,
+            heading_hierarchy TEXT,
+            section TEXT,
+            chunk_id TEXT UNIQUE,
+            content TEXT,
+            url TEXT,
+            hash TEXT,
+            chunk_index INTEGER,
+            total_chunks INTEGER
+        );
+    `);
+    if (!withDatesTable) {
+        // Simulate a database created before chunk creation dates existed
+        db.exec(`DROP TABLE IF EXISTS vec_chunk_dates;`);
+    }
+    return db;
+}
+
+function makeChunk(overrides: Partial<DocumentChunk['metadata']> & { content?: string } = {}): DocumentChunk {
+    const { content, ...meta } = overrides;
+    return {
+        content: content ?? 'Chunk content',
+        metadata: {
+            product_name: 'TestSite',
+            version: '1.0',
+            branch: '',
+            repo: '',
+            heading_hierarchy: ['Guide', 'Install'],
+            section: 'Install',
+            chunk_id: 'chunk-1',
+            url: 'https://example.com/page',
+            chunk_index: 0,
+            total_chunks: 1,
+            ...meta,
+        },
+    };
+}
+
+function configYaml(params: string): string {
+    return `
+sources:
+  - type: website
+    product_name: TestSite
+    version: '1.0'
+    max_size: 1000
+    url: https://example.com
+    database_config:
+      type: sqlite
+      params:
+        ${params}
+`;
+}
+
+beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chunk-inspector-'));
+    dbPath = path.join(tmpDir, 'test.db');
+});
+
+afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.CHUNK_INSPECTOR_TEST_DB;
+});
+
+describe('lookupChunks (sqlite)', () => {
+    it('returns the chunks stored for a URL, newest first, with content and metadata', async () => {
+        const db = createDbFile();
+        const embedding = [0.1, 0.2, 0.3, 0.4];
+        DatabaseManager.insertVectorsSQLite(db, makeChunk({ chunk_id: 'chunk-old', content: 'Old chunk', chunk_index: 0, total_chunks: 2 }), embedding, testLogger);
+        DatabaseManager.insertVectorsSQLite(db, makeChunk({ chunk_id: 'chunk-new', content: 'New chunk', chunk_index: 1, total_chunks: 2 }), embedding, testLogger);
+        // Force distinct creation dates so ordering is deterministic
+        db.prepare(`UPDATE vec_chunk_dates SET created_at = ? WHERE chunk_id = ?`).run('2026-01-01T00:00:00.000Z', 'chunk-old');
+        db.prepare(`UPDATE vec_chunk_dates SET created_at = ? WHERE chunk_id = ?`).run('2026-06-01T00:00:00.000Z', 'chunk-new');
+        db.close();
+
+        const result = await lookupChunks(
+            configYaml(`db_path: ${dbPath}`),
+            { product_name: 'TestSite' },
+            'https://example.com/page'
+        );
+
+        expect(result.database).toEqual({ type: 'sqlite', path: dbPath });
+        expect(result.source).toEqual({ product_name: 'TestSite', type: 'website', version: '1.0' });
+        expect(result.chunks).toHaveLength(2);
+        expect(result.chunks[0].chunk_id).toBe('chunk-new');
+        expect(result.chunks[0].created_at).toBe('2026-06-01T00:00:00.000Z');
+        expect(result.chunks[0].content).toBe('New chunk');
+        expect(result.chunks[0].heading_hierarchy).toEqual(['Guide', 'Install']);
+        expect(result.chunks[1].chunk_id).toBe('chunk-old');
+    });
+
+    it('returns an empty list for a URL with no chunks', async () => {
+        createDbFile().close();
+
+        const result = await lookupChunks(
+            configYaml(`db_path: ${dbPath}`),
+            { product_name: 'TestSite' },
+            'https://example.com/nope'
+        );
+
+        expect(result.chunks).toEqual([]);
+    });
+
+    it('returns chunks with a null created_at for databases predating the dates table', async () => {
+        const db = createDbFile();
+        DatabaseManager.insertVectorsSQLite(db, makeChunk(), [0.1, 0.2, 0.3, 0.4], testLogger);
+        db.exec(`DROP TABLE vec_chunk_dates;`);
+        db.close();
+
+        const result = await lookupChunks(
+            configYaml(`db_path: ${dbPath}`),
+            { product_name: 'TestSite' },
+            'https://example.com/page'
+        );
+
+        expect(result.chunks).toHaveLength(1);
+        expect(result.chunks[0].created_at).toBeNull();
+    });
+
+    it('substitutes ${ENV_VAR} placeholders in the config like a sync job would', async () => {
+        const db = createDbFile();
+        DatabaseManager.insertVectorsSQLite(db, makeChunk(), [0.1, 0.2, 0.3, 0.4], testLogger);
+        db.close();
+        process.env.CHUNK_INSPECTOR_TEST_DB = dbPath;
+
+        const result = await lookupChunks(
+            // eslint-disable-next-line no-template-curly-in-string
+            configYaml('db_path: ${CHUNK_INSPECTOR_TEST_DB}'),
+            { product_name: 'TestSite' },
+            'https://example.com/page'
+        );
+
+        expect(result.chunks).toHaveLength(1);
+    });
+
+    it('throws NotFoundError for a source that is not in the config', async () => {
+        await expect(lookupChunks(
+            configYaml(`db_path: ${dbPath}`),
+            { product_name: 'Unknown' },
+            'https://example.com/page'
+        )).rejects.toBeInstanceOf(NotFoundError);
+    });
+
+    it('throws NotFoundError when the database file does not exist yet', async () => {
+        await expect(lookupChunks(
+            configYaml(`db_path: ${path.join(tmpDir, 'missing.db')}`),
+            { product_name: 'TestSite' },
+            'https://example.com/page'
+        )).rejects.toBeInstanceOf(NotFoundError);
+    });
+
+    it('matches a source by version when several share a product name', async () => {
+        const db = createDbFile();
+        DatabaseManager.insertVectorsSQLite(db, makeChunk(), [0.1, 0.2, 0.3, 0.4], testLogger);
+        db.close();
+        const otherDbPath = path.join(tmpDir, 'other.db');
+        const content = `
+sources:
+  - type: website
+    product_name: TestSite
+    version: '2.0'
+    max_size: 1000
+    url: https://example.com/v2
+    database_config:
+      type: sqlite
+      params:
+        db_path: ${otherDbPath}
+  - type: website
+    product_name: TestSite
+    version: '1.0'
+    max_size: 1000
+    url: https://example.com
+    database_config:
+      type: sqlite
+      params:
+        db_path: ${dbPath}
+`;
+
+        const result = await lookupChunks(content, { product_name: 'TestSite', version: '1.0' }, 'https://example.com/page');
+
+        expect(result.database).toEqual({ type: 'sqlite', path: dbPath });
+        expect(result.chunks).toHaveLength(1);
+    });
+});

--- a/tests/controller-server-chunks.test.ts
+++ b/tests/controller-server-chunks.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import BetterSqlite3 from 'better-sqlite3';
+import * as sqliteVec from 'sqlite-vec';
+import { createServer } from '../controller/server';
+import { DatabaseManager } from '../database';
+import { Logger, LogLevel } from '../logger';
+
+const testLogger = new Logger('server-chunks-test', { level: LogLevel.NONE });
+
+let tmpDir: string;
+let dbPath: string;
+let server: http.Server;
+let baseUrl: string;
+
+function configContent(): string {
+    return `
+sources:
+  - type: website
+    product_name: TestSite
+    version: '1.0'
+    max_size: 1000
+    url: https://example.com
+    database_config:
+      type: sqlite
+      params:
+        db_path: ${dbPath}
+`;
+}
+
+// Minimal stand-ins for the controller wiring — the route under test only
+// touches registry.get() and the config content.
+function makeDeps(): any {
+    return {
+        store: {},
+        registry: {
+            get: (id: number) => (id === 1 ? { id: 1, name: 'test', content: configContent() } : undefined),
+            list: () => [],
+        },
+        scheduler: { nextRun: () => null },
+        runner: { isBusy: () => false },
+        events: { on: () => {}, off: () => {} },
+        readWrite: false,
+        logger: testLogger,
+    };
+}
+
+async function get(pathname: string): Promise<{ status: number; body: any }> {
+    const res = await fetch(`${baseUrl}${pathname}`);
+    return { status: res.status, body: await res.json().catch(() => null) };
+}
+
+beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'server-chunks-'));
+    dbPath = path.join(tmpDir, 'test.db');
+
+    const db = new BetterSqlite3(dbPath, { allowExtension: true } as any);
+    sqliteVec.load(db);
+    db.exec(`
+        CREATE VIRTUAL TABLE IF NOT EXISTS vec_items USING vec0(
+            embedding FLOAT[4],
+            product_name TEXT,
+            version TEXT,
+            branch TEXT,
+            repo TEXT,
+            heading_hierarchy TEXT,
+            section TEXT,
+            chunk_id TEXT UNIQUE,
+            content TEXT,
+            url TEXT,
+            hash TEXT,
+            chunk_index INTEGER,
+            total_chunks INTEGER
+        );
+    `);
+    DatabaseManager.insertVectorsSQLite(db, {
+        content: 'Hello chunk',
+        metadata: {
+            product_name: 'TestSite',
+            version: '1.0',
+            branch: '',
+            repo: '',
+            heading_hierarchy: ['Docs'],
+            section: 'Docs',
+            chunk_id: 'chunk-1',
+            url: 'https://example.com/page',
+            chunk_index: 0,
+            total_chunks: 1,
+        },
+    }, [0.1, 0.2, 0.3, 0.4], testLogger);
+    db.close();
+
+    const app = createServer(makeDeps());
+    server = http.createServer(app);
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address() as any;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+    await new Promise<void>((resolve, reject) => server.close(err => (err ? reject(err) : resolve())));
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('GET /api/configs/:id/chunks', () => {
+    it('returns the stored chunks for a URL', async () => {
+        const { status, body } = await get(
+            `/api/configs/1/chunks?product_name=TestSite&url=${encodeURIComponent('https://example.com/page')}`
+        );
+
+        expect(status).toBe(200);
+        expect(body.source).toEqual({ product_name: 'TestSite', type: 'website', version: '1.0' });
+        expect(body.chunks).toHaveLength(1);
+        expect(body.chunks[0].content).toBe('Hello chunk');
+        expect(body.chunks[0].created_at).toBeTruthy();
+    });
+
+    it('400s without a url parameter', async () => {
+        const { status } = await get('/api/configs/1/chunks?product_name=TestSite');
+        expect(status).toBe(400);
+    });
+
+    it('400s without a product_name parameter', async () => {
+        const { status } = await get(`/api/configs/1/chunks?url=${encodeURIComponent('https://example.com/page')}`);
+        expect(status).toBe(400);
+    });
+
+    it('404s for an unknown config', async () => {
+        const { status } = await get(
+            `/api/configs/99/chunks?product_name=TestSite&url=${encodeURIComponent('https://example.com/page')}`
+        );
+        expect(status).toBe(404);
+    });
+
+    it('404s for a source that is not in the config', async () => {
+        const { status, body } = await get(
+            `/api/configs/1/chunks?product_name=Nope&url=${encodeURIComponent('https://example.com/page')}`
+        );
+        expect(status).toBe(404);
+        expect(body.error).toContain('Nope');
+    });
+});

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -227,6 +227,17 @@ describe('DatabaseManager', () => {
             expect(result.product_name).toBe('TestProduct');
         });
 
+        it('should record a creation date for each inserted chunk', () => {
+            const chunk = createTestChunk();
+            DatabaseManager.insertVectorsSQLite(db, chunk, createTestEmbedding(), testLogger);
+
+            const row = db.prepare('SELECT created_at FROM vec_chunk_dates WHERE chunk_id = ?')
+                .get(chunk.metadata.chunk_id) as any;
+
+            expect(row).toBeDefined();
+            expect(new Date(row.created_at).getTime()).not.toBeNaN();
+        });
+
         it('should handle duplicate chunk_id inserts gracefully', () => {
             // Note: vec0 virtual tables silently ignore duplicate UNIQUE inserts
             // rather than throwing an error. This means the update path in
@@ -414,6 +425,27 @@ describe('DatabaseManager', () => {
             expect(remaining.length).toBe(1);
             expect(remaining[0].chunk_id).toBe('out-of-scope');
         });
+
+        it('should report deleted URL and chunk counts', () => {
+            const embedding = createTestEmbedding();
+            // Two chunks on one obsolete page, one chunk on another
+            for (const [chunkId, url] of [
+                ['gone-1a', 'https://example.com/gone1'],
+                ['gone-1b', 'https://example.com/gone1'],
+                ['gone-2', 'https://example.com/gone2'],
+                ['kept', 'https://example.com/kept'],
+            ]) {
+                const chunk = createTestChunk();
+                chunk.metadata.chunk_id = chunkId;
+                chunk.metadata.url = url;
+                DatabaseManager.insertVectorsSQLite(db, chunk, embedding, testLogger);
+            }
+
+            const visitedUrls = new Set(['https://example.com/kept']);
+            const removed = DatabaseManager.removeObsoleteChunksSQLite(db, visitedUrls, 'https://example.com', testLogger);
+
+            expect(removed).toEqual({ items: 2, chunks: 3 });
+        });
     });
 
     // ─── removeChunksByUrlSQLite ─────────────────────────────────────
@@ -453,6 +485,19 @@ describe('DatabaseManager', () => {
         it('should not error when no chunks match', () => {
             DatabaseManager.removeChunksByUrlSQLite(db, 'https://nonexistent.com/page', testLogger);
             // Should not throw
+        });
+
+        it('should return the number of deleted chunks', () => {
+            const embedding = createTestEmbedding();
+            for (let i = 0; i < 3; i++) {
+                const chunk = createTestChunk();
+                chunk.metadata.chunk_id = `chunk-${i}`;
+                chunk.metadata.url = 'https://example.com/target';
+                DatabaseManager.insertVectorsSQLite(db, chunk, embedding, testLogger);
+            }
+
+            expect(DatabaseManager.removeChunksByUrlSQLite(db, 'https://example.com/target', testLogger)).toBe(3);
+            expect(DatabaseManager.removeChunksByUrlSQLite(db, 'https://example.com/target', testLogger)).toBe(0);
         });
     });
 

--- a/tests/doc2vec.test.ts
+++ b/tests/doc2vec.test.ts
@@ -66,12 +66,12 @@ vi.mock('../database', () => ({
         }),
         insertVectorsSQLite: vi.fn(),
         storeChunkInQdrant: vi.fn().mockResolvedValue(undefined),
-        removeObsoleteChunksSQLite: vi.fn(),
-        removeObsoleteChunksQdrant: vi.fn().mockResolvedValue(undefined),
-        removeObsoleteFilesSQLite: vi.fn(),
-        removeObsoleteFilesQdrant: vi.fn().mockResolvedValue(undefined),
-        removeChunksByUrlSQLite: vi.fn(),
-        removeChunksByUrlQdrant: vi.fn().mockResolvedValue(undefined),
+        removeObsoleteChunksSQLite: vi.fn().mockReturnValue({ items: 0, chunks: 0 }),
+        removeObsoleteChunksQdrant: vi.fn().mockResolvedValue({ items: 0, chunks: 0 }),
+        removeObsoleteFilesSQLite: vi.fn().mockReturnValue({ items: 0, chunks: 0 }),
+        removeObsoleteFilesQdrant: vi.fn().mockResolvedValue({ items: 0, chunks: 0 }),
+        removeChunksByUrlSQLite: vi.fn().mockReturnValue(0),
+        removeChunksByUrlQdrant: vi.fn().mockResolvedValue(0),
         getChunkHashesByUrlSQLite: vi.fn().mockReturnValue([]),
         getChunkHashesByUrlQdrant: vi.fn().mockResolvedValue([]),
         getStoredUrlsByPrefixSQLite: vi.fn().mockReturnValue([]),
@@ -1976,6 +1976,116 @@ sources:
                 issueUrl(42),
                 expect.anything(),
             );
+        });
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Source run counters (per-source stats surfaced in the controller UI)
+    // ─────────────────────────────────────────────────────────────────────────
+    describe('source run counters', () => {
+        const url = 'https://example.com/page';
+        const dbConnection = { type: 'sqlite', db: {} };
+
+        function makeChunk(content: string, index = 0, total = 1) {
+            return {
+                content,
+                metadata: {
+                    product_name: 'TestSite',
+                    version: '1.0',
+                    heading_hierarchy: [],
+                    section: 'S',
+                    chunk_id: `chunk-${index}`,
+                    url,
+                    chunk_index: index,
+                    total_chunks: total,
+                },
+            };
+        }
+
+        async function makeInstanceWithEmbeddings() {
+            const { __mockEmbeddingsCreate } = await import('openai') as any;
+            __mockEmbeddingsCreate.mockResolvedValue({ data: [{ embedding: [0.1, 0.2] }] });
+            const configPath = writeTestConfig('counters.yaml', makeMinimalConfig());
+            return new Doc2Vec(configPath) as any;
+        }
+
+        it('counts a URL with no stored chunks as new and tallies added chunks', async () => {
+            const instance = await makeInstanceWithEmbeddings();
+            (DatabaseManager.getChunkHashesByUrlSQLite as any).mockReturnValue([]);
+
+            await instance.processChunksForUrl([makeChunk('a'), makeChunk('b', 1, 2)], url, dbConnection, instance.logger);
+
+            expect(instance.counters.items_new).toBe(1);
+            expect(instance.counters.items_updated).toBe(0);
+            expect(instance.counters.items_unchanged).toBe(0);
+            expect(instance.counters.chunks_added).toBe(2);
+            expect(instance.counters.chunks_deleted).toBe(0);
+        });
+
+        it('counts an identical URL as unchanged with no chunk churn', async () => {
+            const instance = await makeInstanceWithEmbeddings();
+            const { Utils } = await import('../utils');
+            (Utils.generateHash as any).mockImplementation((content: string) => `hash-${content}`);
+            (DatabaseManager.getChunkHashesByUrlSQLite as any).mockReturnValue(['hash-a']);
+
+            await instance.processChunksForUrl([makeChunk('a')], url, dbConnection, instance.logger);
+
+            expect(instance.counters.items_unchanged).toBe(1);
+            expect(instance.counters.items_new).toBe(0);
+            expect(instance.counters.chunks_added).toBe(0);
+            expect(instance.counters.chunks_deleted).toBe(0);
+        });
+
+        it('counts a changed URL as updated, deleting old chunks and adding new ones', async () => {
+            const instance = await makeInstanceWithEmbeddings();
+            const { Utils } = await import('../utils');
+            (Utils.generateHash as any).mockImplementation((content: string) => `hash-${content}`);
+            (DatabaseManager.getChunkHashesByUrlSQLite as any).mockReturnValue(['hash-old-1', 'hash-old-2', 'hash-old-3']);
+
+            await instance.processChunksForUrl([makeChunk('a')], url, dbConnection, instance.logger);
+
+            expect(instance.counters.items_updated).toBe(1);
+            expect(instance.counters.chunks_deleted).toBe(3);
+            expect(instance.counters.chunks_added).toBe(1);
+        });
+
+        it('attaches counters with the source-appropriate item kind to run() stats', async () => {
+            const configPath = writeTestConfig('counters-run.yaml', makeMinimalConfig());
+            const instance = new Doc2Vec(configPath);
+            (instance as any).contentProcessor.crawlWebsite = vi.fn().mockResolvedValue({
+                hasNetworkErrors: false,
+                brokenLinks: [],
+            });
+
+            const stats = await instance.run();
+
+            expect(stats).toHaveLength(1);
+            expect(stats[0].counters).toMatchObject({
+                items_kind: 'pages',
+                items_new: 0,
+                items_updated: 0,
+                items_unchanged: 0,
+                items_deleted: 0,
+                chunks_added: 0,
+                chunks_deleted: 0,
+            });
+        });
+
+        it('counts obsolete cleanup results as deleted items and chunks', async () => {
+            const configPath = writeTestConfig('counters-cleanup.yaml', makeMinimalConfig());
+            const instance = new Doc2Vec(configPath);
+            (instance as any).contentProcessor.crawlWebsite = vi.fn().mockResolvedValue({
+                hasNetworkErrors: false,
+                brokenLinks: [],
+            });
+            (DatabaseManager.removeObsoleteChunksSQLite as any).mockReturnValue({ items: 2, chunks: 7 });
+
+            const stats = await instance.run();
+
+            expect(stats[0].counters).toMatchObject({
+                items_deleted: 2,
+                chunks_deleted: 7,
+            });
         });
     });
 });

--- a/types.ts
+++ b/types.ts
@@ -152,6 +152,31 @@ export interface BrokenLink {
     target: string;
 }
 
+// Change counters accumulated while syncing a single source. "Items" are the
+// source's natural unit (pages for websites, files for directories/code,
+// issues for GitHub, objects for S3, tickets/articles for Zendesk).
+export interface SourceRunCounters {
+    items_kind: string;
+    items_new: number;       // items that had no chunks stored before this run
+    items_updated: number;   // items whose content changed and were re-embedded
+    items_unchanged: number; // items skipped because stored chunks were identical
+    items_deleted: number;   // items purged from the store (404s, obsolete files, deleted tickets…)
+    chunks_added: number;
+    chunks_deleted: number;
+}
+
+export function newSourceRunCounters(itemsKind: string): SourceRunCounters {
+    return {
+        items_kind: itemsKind,
+        items_new: 0,
+        items_updated: 0,
+        items_unchanged: 0,
+        items_deleted: 0,
+        chunks_added: 0,
+        chunks_deleted: 0,
+    };
+}
+
 // Per-source outcome of a sync run, emitted as the `run-summary` structured event
 // and consumed by the controller to build run statistics
 export interface SourceRunStats {
@@ -161,6 +186,7 @@ export interface SourceRunStats {
     duration_ms: number;
     ok: boolean;
     error?: string;
+    counters?: SourceRunCounters;
 }
 
 export interface SqliteDB {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -5,6 +5,7 @@ import { api } from './api';
 import Dashboard from './pages/Dashboard';
 import ConfigDetail from './pages/ConfigDetail';
 import RunDetail from './pages/RunDetail';
+import RunSourceDetail from './pages/RunSourceDetail';
 
 export default function App() {
   const queryClient = useQueryClient();
@@ -50,6 +51,7 @@ export default function App() {
           <Route path="/" element={<Dashboard />} />
           <Route path="/configs/:id" element={<ConfigDetail />} />
           <Route path="/runs/:id" element={<RunDetail />} />
+          <Route path="/runs/:id/sources/:sourceIndex" element={<RunSourceDetail />} />
         </Routes>
       </main>
     </div>

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -8,6 +8,26 @@ export interface SourceSummary {
 
 export type RunStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'skipped' | 'canceled';
 
+export interface SourceRunCounters {
+  items_kind: string;
+  items_new: number;
+  items_updated: number;
+  items_unchanged: number;
+  items_deleted: number;
+  chunks_added: number;
+  chunks_deleted: number;
+}
+
+export interface SourceRunStats {
+  product_name: string;
+  type: string;
+  version: string;
+  duration_ms: number;
+  ok: boolean;
+  error?: string;
+  counters?: SourceRunCounters;
+}
+
 export interface RunRecord {
   id: number;
   config_id: number;
@@ -18,14 +38,7 @@ export interface RunRecord {
   exit_code: number | null;
   error: string | null;
   stats: {
-    sources?: Array<{
-      product_name: string;
-      type: string;
-      version: string;
-      duration_ms: number;
-      ok: boolean;
-      error?: string;
-    }>;
+    sources?: SourceRunStats[];
     warn_count?: number;
     error_count?: number;
   };
@@ -33,6 +46,26 @@ export interface RunRecord {
   started_at: string | null;
   finished_at: string | null;
   config_name?: string | null;
+}
+
+export interface ChunkRecord {
+  chunk_id: string;
+  url: string;
+  product_name: string | null;
+  version: string | null;
+  section: string | null;
+  heading_hierarchy: string[];
+  chunk_index: number | null;
+  total_chunks: number | null;
+  hash: string | null;
+  created_at: string | null;
+  content: string;
+}
+
+export interface ChunkLookupResult {
+  source: { product_name: string; type: string; version: string };
+  database: { type: 'sqlite'; path: string } | { type: 'qdrant'; url: string; collection: string };
+  chunks: ChunkRecord[];
 }
 
 export interface ConfigRecord {
@@ -112,6 +145,14 @@ export const api = {
   triggerRun: (configId: number) => request<RunRecord>(`/api/configs/${configId}/run`, { method: 'POST' }),
   configStats: (configId: number, days: number) =>
     request<ConfigStats>(`/api/configs/${configId}/stats?days=${days}`),
+  chunksForUrl: (configId: number, params: { product_name: string; type?: string; version?: string; url: string }) => {
+    const qs = new URLSearchParams();
+    qs.set('product_name', params.product_name);
+    if (params.type) qs.set('type', params.type);
+    if (params.version) qs.set('version', params.version);
+    qs.set('url', params.url);
+    return request<ChunkLookupResult>(`/api/configs/${configId}/chunks?${qs}`);
+  },
   runs: (params: { configId?: number; status?: string; limit?: number; before?: number } = {}) => {
     const qs = new URLSearchParams();
     if (params.configId !== undefined) qs.set('configId', String(params.configId));

--- a/ui/src/pages/RunDetail.tsx
+++ b/ui/src/pages/RunDetail.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { api, ApiError } from '../api';
 import { formatDuration, formatTime, runDuration } from '../lib/format';
 import LogViewer from '../components/LogViewer';
@@ -9,6 +9,7 @@ export default function RunDetail() {
   const { id } = useParams();
   const runId = Number(id);
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const { data: run, error } = useQuery({
     queryKey: ['runs', runId],
@@ -76,16 +77,36 @@ export default function RunDetail() {
                 <th className="px-4 py-2 font-medium">Type</th>
                 <th className="px-4 py-2 font-medium">Version</th>
                 <th className="px-4 py-2 font-medium">Duration</th>
+                <th className="px-4 py-2 font-medium">Changes</th>
                 <th className="px-4 py-2 font-medium">Result</th>
+                <th className="px-4 py-2" />
               </tr>
             </thead>
             <tbody>
-              {sources.map(source => (
-                <tr key={`${source.product_name}-${source.type}`} className="border-b border-edge/60 last:border-0">
+              {sources.map((source, index) => (
+                <tr
+                  key={`${source.product_name}-${source.type}-${index}`}
+                  onClick={() => navigate(`/runs/${run.id}/sources/${index}`)}
+                  className="cursor-pointer border-b border-edge/60 transition last:border-0 hover:bg-edge/20"
+                >
                   <td className="px-4 py-2 font-medium">{source.product_name}</td>
                   <td className="px-4 py-2 text-ink-secondary">{source.type}</td>
                   <td className="px-4 py-2 text-ink-secondary">{source.version}</td>
                   <td className="px-4 py-2 text-ink-secondary">{formatDuration(source.duration_ms / 1000)}</td>
+                  <td className="px-4 py-2 text-ink-secondary">
+                    {source.counters ? (
+                      <span className="whitespace-nowrap tabular-nums">
+                        <span className={source.counters.items_new > 0 ? 'text-good-text' : ''}>+{source.counters.items_new}</span>
+                        {' '}
+                        <span>~{source.counters.items_updated}</span>
+                        {' '}
+                        <span className={source.counters.items_deleted > 0 ? 'text-critical' : ''}>−{source.counters.items_deleted}</span>
+                        <span className="ml-1 text-xs text-ink-muted">{source.counters.items_kind}</span>
+                      </span>
+                    ) : (
+                      '—'
+                    )}
+                  </td>
                   <td className="px-4 py-2">
                     {source.ok ? (
                       <span className="text-good-text">✓ ok</span>
@@ -93,6 +114,7 @@ export default function RunDetail() {
                       <span className="text-critical" title={source.error}>✕ {source.error ?? 'failed'}</span>
                     )}
                   </td>
+                  <td className="px-4 py-2 text-ink-muted">›</td>
                 </tr>
               ))}
             </tbody>

--- a/ui/src/pages/RunSourceDetail.tsx
+++ b/ui/src/pages/RunSourceDetail.tsx
@@ -1,0 +1,251 @@
+import { FormEvent, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link, useParams } from 'react-router-dom';
+import { api, ApiError, ChunkLookupResult, ChunkRecord, SourceRunCounters } from '../api';
+import { formatDuration, formatTime } from '../lib/format';
+import RunStatusBadge from '../components/RunStatusBadge';
+
+// Singularize the item kind for per-source stat labels ("New pages" → kind "pages")
+function statCards(counters: SourceRunCounters): Array<{ label: string; value: number; tone?: 'good' | 'bad' }> {
+  const kind = counters.items_kind || 'items';
+  return [
+    { label: `New ${kind}`, value: counters.items_new, tone: 'good' },
+    { label: `Updated ${kind}`, value: counters.items_updated },
+    { label: `Unchanged ${kind}`, value: counters.items_unchanged },
+    { label: `Deleted ${kind}`, value: counters.items_deleted, tone: 'bad' },
+    { label: 'Chunks added', value: counters.chunks_added, tone: 'good' },
+    { label: 'Chunks deleted', value: counters.chunks_deleted, tone: 'bad' },
+  ];
+}
+
+function ChunkRow({ chunk }: { chunk: ChunkRecord }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <tr
+        onClick={() => setOpen(o => !o)}
+        className="cursor-pointer border-b border-edge/60 transition last:border-0 hover:bg-edge/20"
+      >
+        <td className="px-4 py-2 text-ink-secondary">{chunk.created_at ? formatTime(chunk.created_at) : '—'}</td>
+        <td className="px-4 py-2 font-mono text-xs text-ink-secondary" title={chunk.chunk_id}>
+          {chunk.chunk_id.slice(0, 10)}…
+        </td>
+        <td className="px-4 py-2 text-ink-secondary">
+          {chunk.chunk_index !== null && chunk.total_chunks !== null
+            ? `${chunk.chunk_index + 1} / ${chunk.total_chunks}`
+            : '—'}
+        </td>
+        <td className="max-w-xs truncate px-4 py-2 text-ink-secondary" title={chunk.section ?? undefined}>
+          {chunk.section || '—'}
+        </td>
+        <td className="px-4 py-2 text-right text-ink-muted">{chunk.content.length.toLocaleString()} chars</td>
+        <td className="px-4 py-2 text-ink-muted">{open ? '▾' : '▸'}</td>
+      </tr>
+      {open && (
+        <tr className="border-b border-edge/60 last:border-0">
+          <td colSpan={6} className="bg-edge/10 px-4 py-3">
+            <dl className="mb-3 flex flex-wrap gap-x-8 gap-y-1 text-xs">
+              <div>
+                <dt className="uppercase tracking-wide text-ink-muted">Chunk ID</dt>
+                <dd className="mt-0.5 font-mono text-ink-secondary">{chunk.chunk_id}</dd>
+              </div>
+              {chunk.hash && (
+                <div>
+                  <dt className="uppercase tracking-wide text-ink-muted">Content hash</dt>
+                  <dd className="mt-0.5 font-mono text-ink-secondary">{chunk.hash}</dd>
+                </div>
+              )}
+              {chunk.heading_hierarchy.length > 0 && (
+                <div>
+                  <dt className="uppercase tracking-wide text-ink-muted">Headings</dt>
+                  <dd className="mt-0.5 text-ink-secondary">{chunk.heading_hierarchy.join(' › ')}</dd>
+                </div>
+              )}
+              {chunk.product_name && (
+                <div>
+                  <dt className="uppercase tracking-wide text-ink-muted">Product</dt>
+                  <dd className="mt-0.5 text-ink-secondary">
+                    {chunk.product_name}
+                    {chunk.version ? ` @ ${chunk.version}` : ''}
+                  </dd>
+                </div>
+              )}
+            </dl>
+            <pre className="max-h-96 overflow-auto whitespace-pre-wrap rounded-md border border-edge bg-surface p-3 text-xs text-ink-secondary">
+              {chunk.content}
+            </pre>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+export default function RunSourceDetail() {
+  const { id, sourceIndex } = useParams();
+  const runId = Number(id);
+  const idx = Number(sourceIndex);
+
+  const { data: run, error } = useQuery({
+    queryKey: ['runs', runId],
+    queryFn: () => api.run(runId),
+  });
+
+  const [url, setUrl] = useState('');
+  const [lookupUrl, setLookupUrl] = useState<string | null>(null);
+
+  const source = run?.stats?.sources?.[idx];
+
+  const chunkQuery = useQuery<ChunkLookupResult, ApiError>({
+    queryKey: ['chunks', run?.config_id, source?.product_name, source?.version, lookupUrl],
+    queryFn: () =>
+      api.chunksForUrl(run!.config_id, {
+        product_name: source!.product_name,
+        type: source!.type,
+        version: source!.version,
+        url: lookupUrl!,
+      }),
+    enabled: run !== undefined && source !== undefined && lookupUrl !== null,
+    retry: false,
+  });
+
+  if (error) return <p className="text-critical">{(error as ApiError).message}</p>;
+  if (!run) return <p className="text-ink-muted">Loading…</p>;
+  if (!source) {
+    return (
+      <div className="space-y-2">
+        <Link to={`/runs/${runId}`} className="text-sm text-ink-muted hover:text-accent">
+          ← Run #{runId}
+        </Link>
+        <p className="text-ink-muted">No per-source stats were recorded for this source in this run.</p>
+      </div>
+    );
+  }
+
+  const counters = source.counters;
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const trimmed = url.trim();
+    if (trimmed) setLookupUrl(trimmed);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link to={`/runs/${runId}`} className="text-sm text-ink-muted hover:text-accent">
+          ← Run #{runId}
+        </Link>
+        <div className="mt-2 flex flex-wrap items-center gap-3">
+          <h1 className="text-xl font-semibold tracking-tight">{source.product_name}</h1>
+          <RunStatusBadge status={run.status} />
+          {source.ok ? (
+            <span className="text-sm text-good-text">✓ ok</span>
+          ) : (
+            <span className="text-sm text-critical">✕ {source.error ?? 'failed'}</span>
+          )}
+        </div>
+        <dl className="mt-3 flex flex-wrap gap-x-8 gap-y-2 text-sm">
+          {[
+            ['Type', source.type],
+            ['Version', source.version],
+            ['Duration', formatDuration(source.duration_ms / 1000)],
+            ['Run started', formatTime(run.started_at)],
+          ].map(([label, value]) => (
+            <div key={label}>
+              <dt className="text-xs uppercase tracking-wide text-ink-muted">{label}</dt>
+              <dd className="mt-0.5 text-ink-secondary">{value}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+
+      <div>
+        <h2 className="mb-2 text-sm font-semibold text-ink-secondary">Changes in this run</h2>
+        {counters ? (
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+            {statCards(counters).map(card => (
+              <div key={card.label} className="rounded-lg border border-edge bg-surface px-4 py-3">
+                <div
+                  className={`text-2xl font-semibold tabular-nums ${
+                    card.value === 0
+                      ? 'text-ink-muted'
+                      : card.tone === 'good'
+                        ? 'text-good-text'
+                        : card.tone === 'bad'
+                          ? 'text-critical'
+                          : ''
+                  }`}
+                >
+                  {card.value.toLocaleString()}
+                </div>
+                <div className="mt-1 text-xs uppercase tracking-wide text-ink-muted">{card.label}</div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-ink-muted">
+            This run predates detailed source statistics — trigger a new run to collect them.
+          </p>
+        )}
+      </div>
+
+      <div>
+        <h2 className="mb-2 text-sm font-semibold text-ink-secondary">Chunk lookup</h2>
+        <p className="mb-2 text-xs text-ink-muted">
+          Shows the chunks currently stored in this source's vector database for a URL (live view, newest first).
+        </p>
+        <form onSubmit={onSubmit} className="flex gap-2">
+          <input
+            type="text"
+            value={url}
+            onChange={e => setUrl(e.target.value)}
+            placeholder="https://…"
+            className="w-full max-w-2xl rounded-md border border-edge bg-surface px-3 py-1.5 text-sm outline-none focus:border-accent"
+          />
+          <button
+            type="submit"
+            disabled={!url.trim() || chunkQuery.isFetching}
+            className="rounded-md border border-edge px-3.5 py-1.5 text-sm font-medium transition hover:border-accent hover:text-accent disabled:opacity-40"
+          >
+            {chunkQuery.isFetching ? 'Looking up…' : 'Look up'}
+          </button>
+        </form>
+
+        {chunkQuery.error && <p className="mt-3 text-sm text-critical">{chunkQuery.error.message}</p>}
+
+        {chunkQuery.data && (
+          <div className="mt-4 space-y-2">
+            <p className="text-xs text-ink-muted">
+              {chunkQuery.data.chunks.length} chunk{chunkQuery.data.chunks.length === 1 ? '' : 's'} in{' '}
+              {chunkQuery.data.database.type === 'qdrant'
+                ? `Qdrant collection '${chunkQuery.data.database.collection}'`
+                : `SQLite database ${chunkQuery.data.database.path}`}
+            </p>
+            {chunkQuery.data.chunks.length > 0 && (
+              <div className="overflow-x-auto rounded-lg border border-edge bg-surface">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-edge text-left text-xs uppercase tracking-wide text-ink-muted">
+                      <th className="px-4 py-2 font-medium">Created</th>
+                      <th className="px-4 py-2 font-medium">Chunk</th>
+                      <th className="px-4 py-2 font-medium">Position</th>
+                      <th className="px-4 py-2 font-medium">Section</th>
+                      <th className="px-4 py-2 text-right font-medium">Size</th>
+                      <th className="px-4 py-2" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {chunkQuery.data.chunks.map(chunk => (
+                      <ChunkRow key={chunk.chunk_id} chunk={chunk} />
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/RunSourceDetail.tsx
+++ b/ui/src/pages/RunSourceDetail.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useState } from 'react';
+import { FormEvent, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link, useParams } from 'react-router-dom';
 import { api, ApiError, ChunkLookupResult, ChunkRecord, SourceRunCounters } from '../api';
@@ -18,6 +18,61 @@ function statCards(counters: SourceRunCounters): Array<{ label: string; value: n
   ];
 }
 
+type SortKey = 'chunk_id' | 'position' | 'section' | 'size';
+
+// Default directions: sizes largest-first, the rest ascending
+const DEFAULT_DIR: Record<SortKey, 'asc' | 'desc'> = {
+  chunk_id: 'asc',
+  position: 'asc',
+  section: 'asc',
+  size: 'desc',
+};
+
+function compareChunks(a: ChunkRecord, b: ChunkRecord, key: SortKey, dir: 'asc' | 'desc'): number {
+  const sign = dir === 'asc' ? 1 : -1;
+  switch (key) {
+    case 'chunk_id':
+      return a.chunk_id.localeCompare(b.chunk_id) * sign;
+    case 'position':
+      return ((a.chunk_index ?? Number.MAX_SAFE_INTEGER) - (b.chunk_index ?? Number.MAX_SAFE_INTEGER)) * sign;
+    case 'section':
+      return (a.section ?? '').localeCompare(b.section ?? '') * sign;
+    case 'size':
+      return (a.content.length - b.content.length) * sign;
+  }
+}
+
+function SortableHeader({
+  label,
+  sortKey,
+  sort,
+  onSort,
+  align = 'left',
+}: {
+  label: string;
+  sortKey: SortKey;
+  sort: { key: SortKey; dir: 'asc' | 'desc' };
+  onSort: (key: SortKey) => void;
+  align?: 'left' | 'right';
+}) {
+  const active = sort.key === sortKey;
+  return (
+    <th className={`px-4 py-2 font-medium ${align === 'right' ? 'text-right' : 'text-left'}`}>
+      <button
+        type="button"
+        onClick={() => onSort(sortKey)}
+        className={`inline-flex items-center gap-1 uppercase tracking-wide transition hover:text-accent ${
+          active ? 'text-accent' : ''
+        }`}
+        title={`Sort by ${label.toLowerCase()}`}
+      >
+        {label}
+        <span className={active ? '' : 'opacity-30'}>{active ? (sort.dir === 'asc' ? '▲' : '▼') : '↕'}</span>
+      </button>
+    </th>
+  );
+}
+
 function ChunkRow({ chunk }: { chunk: ChunkRecord }) {
   const [open, setOpen] = useState(false);
   return (
@@ -26,7 +81,6 @@ function ChunkRow({ chunk }: { chunk: ChunkRecord }) {
         onClick={() => setOpen(o => !o)}
         className="cursor-pointer border-b border-edge/60 transition last:border-0 hover:bg-edge/20"
       >
-        <td className="px-4 py-2 text-ink-secondary">{chunk.created_at ? formatTime(chunk.created_at) : '—'}</td>
         <td className="px-4 py-2 font-mono text-xs text-ink-secondary" title={chunk.chunk_id}>
           {chunk.chunk_id.slice(0, 10)}…
         </td>
@@ -43,7 +97,7 @@ function ChunkRow({ chunk }: { chunk: ChunkRecord }) {
       </tr>
       {open && (
         <tr className="border-b border-edge/60 last:border-0">
-          <td colSpan={6} className="bg-edge/10 px-4 py-3">
+          <td colSpan={5} className="bg-edge/10 px-4 py-3">
             <dl className="mb-3 flex flex-wrap gap-x-8 gap-y-1 text-xs">
               <div>
                 <dt className="uppercase tracking-wide text-ink-muted">Chunk ID</dt>
@@ -53,6 +107,12 @@ function ChunkRow({ chunk }: { chunk: ChunkRecord }) {
                 <div>
                   <dt className="uppercase tracking-wide text-ink-muted">Content hash</dt>
                   <dd className="mt-0.5 font-mono text-ink-secondary">{chunk.hash}</dd>
+                </div>
+              )}
+              {chunk.created_at && (
+                <div>
+                  <dt className="uppercase tracking-wide text-ink-muted">Created / Updated</dt>
+                  <dd className="mt-0.5 text-ink-secondary">{formatTime(chunk.created_at)}</dd>
                 </div>
               )}
               {chunk.heading_hierarchy.length > 0 && (
@@ -93,6 +153,10 @@ export default function RunSourceDetail() {
 
   const [url, setUrl] = useState('');
   const [lookupUrl, setLookupUrl] = useState<string | null>(null);
+  const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' }>({ key: 'position', dir: 'asc' });
+
+  const onSort = (key: SortKey) =>
+    setSort(prev => (prev.key === key ? { key, dir: prev.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: DEFAULT_DIR[key] }));
 
   const source = run?.stats?.sources?.[idx];
 
@@ -108,6 +172,17 @@ export default function RunSourceDetail() {
     enabled: run !== undefined && source !== undefined && lookupUrl !== null,
     retry: false,
   });
+
+  const sortedChunks = useMemo(
+    () => (chunkQuery.data ? [...chunkQuery.data.chunks].sort((a, b) => compareChunks(a, b, sort.key, sort.dir)) : []),
+    [chunkQuery.data, sort]
+  );
+  // A changed URL has all its chunks recreated together, so they share one
+  // date — surface the newest as the URL's created/updated date.
+  const urlDate = useMemo(() => {
+    const dates = (chunkQuery.data?.chunks ?? []).map(c => c.created_at).filter((d): d is string => !!d);
+    return dates.length > 0 ? dates.reduce((a, b) => (a > b ? a : b)) : null;
+  }, [chunkQuery.data]);
 
   if (error) return <p className="text-critical">{(error as ApiError).message}</p>;
   if (!run) return <p className="text-ink-muted">Loading…</p>;
@@ -193,7 +268,8 @@ export default function RunSourceDetail() {
       <div>
         <h2 className="mb-2 text-sm font-semibold text-ink-secondary">Chunk lookup</h2>
         <p className="mb-2 text-xs text-ink-muted">
-          Shows the chunks currently stored in this source's vector database for a URL (live view, newest first).
+          Shows the chunks currently stored in this source's vector database for a URL (live view, ordered by
+          position — click a column heading to sort).
         </p>
         <form onSubmit={onSubmit} className="flex gap-2">
           <input
@@ -215,28 +291,46 @@ export default function RunSourceDetail() {
         {chunkQuery.error && <p className="mt-3 text-sm text-critical">{chunkQuery.error.message}</p>}
 
         {chunkQuery.data && (
-          <div className="mt-4 space-y-2">
-            <p className="text-xs text-ink-muted">
-              {chunkQuery.data.chunks.length} chunk{chunkQuery.data.chunks.length === 1 ? '' : 's'} in{' '}
-              {chunkQuery.data.database.type === 'qdrant'
-                ? `Qdrant collection '${chunkQuery.data.database.collection}'`
-                : `SQLite database ${chunkQuery.data.database.path}`}
-            </p>
+          <div className="mt-4 space-y-3">
+            <dl className="flex flex-wrap gap-x-8 gap-y-2 text-sm">
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-ink-muted">Chunks</dt>
+                <dd className="mt-0.5 text-ink-secondary">{chunkQuery.data.chunks.length}</dd>
+              </div>
+              {chunkQuery.data.chunks.length > 0 && (
+                <div>
+                  <dt className="text-xs uppercase tracking-wide text-ink-muted">Created / Updated</dt>
+                  <dd
+                    className="mt-0.5 text-ink-secondary"
+                    title={urlDate ?? 'No date recorded: these chunks were stored before dates were tracked. A date is set when the page content changes and its chunks are recreated.'}
+                  >
+                    {urlDate ? formatTime(urlDate) : 'unknown (synced before dates were recorded)'}
+                  </dd>
+                </div>
+              )}
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-ink-muted">Store</dt>
+                <dd className="mt-0.5 text-ink-secondary">
+                  {chunkQuery.data.database.type === 'qdrant'
+                    ? `Qdrant collection '${chunkQuery.data.database.collection}'`
+                    : `SQLite ${chunkQuery.data.database.path}`}
+                </dd>
+              </div>
+            </dl>
             {chunkQuery.data.chunks.length > 0 && (
               <div className="overflow-x-auto rounded-lg border border-edge bg-surface">
                 <table className="w-full text-sm">
                   <thead>
-                    <tr className="border-b border-edge text-left text-xs uppercase tracking-wide text-ink-muted">
-                      <th className="px-4 py-2 font-medium">Created</th>
-                      <th className="px-4 py-2 font-medium">Chunk</th>
-                      <th className="px-4 py-2 font-medium">Position</th>
-                      <th className="px-4 py-2 font-medium">Section</th>
-                      <th className="px-4 py-2 text-right font-medium">Size</th>
+                    <tr className="border-b border-edge text-xs text-ink-muted">
+                      <SortableHeader label="Chunk" sortKey="chunk_id" sort={sort} onSort={onSort} />
+                      <SortableHeader label="Position" sortKey="position" sort={sort} onSort={onSort} />
+                      <SortableHeader label="Section" sortKey="section" sort={sort} onSort={onSort} />
+                      <SortableHeader label="Size" sortKey="size" sort={sort} onSort={onSort} align="right" />
                       <th className="px-4 py-2" />
                     </tr>
                   </thead>
                   <tbody>
-                    {chunkQuery.data.chunks.map(chunk => (
+                    {sortedChunks.map(chunk => (
                       <ChunkRow key={chunk.chunk_id} chunk={chunk} />
                     ))}
                   </tbody>


### PR DESCRIPTION
## What

In controller mode, each source in a run is now clickable and leads to a new per-source detail page (`/runs/:id/sources/:index`) that shows:

- **Change stats for the run**, adjusted to the source type (pages for websites, files for directories/code, issues for GitHub, objects for S3, tickets/articles for Zendesk): new / updated / unchanged / deleted items, plus chunks added and deleted. The run page's source table also shows a compact `+new ~updated −deleted` summary column.
- **A chunk lookup form**: type a URL and see the chunks currently stored for it in that source's vector store (live view). The URL's created/updated date is shown above the table, and each chunk can be expanded to inspect its full content and metadata (chunk id, content hash, heading hierarchy, date). Columns are sortable; default order is position within the page.

## How

- `Doc2Vec.run()` accumulates per-source counters (`SourceRunStats.counters`), classified centrally in `processChunksForUrl` (no stored chunks → new, identical hash set → unchanged, else updated) and at the deletion call sites (404 purges, obsolete cleanup, deleted tickets/objects/files). `DatabaseManager` delete helpers now return deletion counts.
- Counters ride the existing `run-summary` event into `d2v_runs.stats` — **no Postgres schema migration needed**; runs from older builds simply show no detailed stats.
- New `GET /api/configs/:id/chunks?product_name&type&version&url` backed by `controller/chunk-inspector.ts`, which resolves the source's store exactly like a sync job (same defaults and `${ENV}` substitution) but opens it strictly read-only (SQLite readonly connection / Qdrant paginated scroll).
- Chunks now record a creation date: a `created_at` payload field in Qdrant, and a `vec_chunk_dates` companion table in SQLite (vec0 virtual tables can't be `ALTER`ed). Since a changed URL has all its chunks recreated together, this date is effectively the URL's "last synced with different content" date. Chunks stored before this change have no date until their content next changes; the UI says so explicitly.

## Tests

- `tests/controller-chunk-inspector.test.ts`: lookup against a real SQLite file — ordering, `${ENV_VAR}` substitution, legacy DBs without the dates table, version disambiguation, not-found cases.
- `tests/controller-server-chunks.test.ts`: drives the real Express route over HTTP (200 / 400 / 404 paths).
- Counter classification tests in `doc2vec.test.ts`, count-return tests in `database.test.ts`.
- Full suite: 621 passed. Version bumped to 2.12.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)