### PR TITLE
fix(github): use cursor pagination and stop losing chunks silently

### DIFF
--- a/content-processor.ts
+++ b/content-processor.ts
@@ -2066,7 +2066,9 @@ export class ContentProcessor {
                 continue;
             }
 
-            const searchableText = contextPrefix + content;
+            // See chunkMarkdown: an unpaired surrogate makes the store's JSON
+            // body invalid, so sanitize before the id is derived from the text.
+            const searchableText = Utils.stripLoneSurrogates(contextPrefix + content);
             const chunkId = Utils.generateHash(`${url}::${searchableText}`);
 
             documentChunks.push({
@@ -2152,7 +2154,10 @@ export class ContentProcessor {
             // to searches for parent topics even if the body doesn't mention them.
             const breadcrumbs = hierarchy.filter(h => h).join(" > ");
             const contextPrefix = breadcrumbs ? `[Topic: ${breadcrumbs}]\n` : "";
-            const searchableText = contextPrefix + content.trim();
+            // Sanitize before hashing so the id and the stored text always agree:
+            // an unpaired surrogate (from a split pair, or straight from the
+            // source) makes the JSON body invalid and the write fails.
+            const searchableText = Utils.stripLoneSurrogates(contextPrefix + content.trim());
             const chunkId = Utils.generateHash(searchableText);
             
             const chunk: DocumentChunk = {
@@ -2199,7 +2204,11 @@ export class ContentProcessor {
                 const overlapSize = Math.floor(MAX_CHARS * OVERLAP_PERCENT);
 
                 for (let i = 0; i < trimmedBuffer.length; i += (MAX_CHARS - overlapSize)) {
-                    const subContent = trimmedBuffer.slice(i, i + MAX_CHARS);
+                    // Slice on code points, not code units: a boundary falling
+                    // inside a surrogate pair (emoji, some CJK) would leave a
+                    // lone surrogate, which Qdrant's JSON parser rejects — the
+                    // chunk then fails to store and is silently lost.
+                    const subContent = Utils.sliceSafe(trimmedBuffer, i, i + MAX_CHARS);
                     chunks.push(createDocumentChunk(subContent, topicHierarchy));
                 }
             } else {

--- a/doc2vec.ts
+++ b/doc2vec.ts
@@ -268,22 +268,33 @@ export class Doc2Vec {
         const startDate = sourceConfig.start_date || '2025-01-01';
         const lastRunDate = await DatabaseManager.getLastRunDate(dbConnection, repo, `${startDate}T00:00:00Z`, logger);
 
-        const fetchWithRetry = async (url: string, params = {}, retries = 5, delay = 5000): Promise<any> => {
+        // Retryable: 5xx, 429, rate-limited 403s, and network/timeout errors.
+        // Everything else is deterministic — the same request fails identically,
+        // so retrying only burns wall-clock. In particular a 422 from deep
+        // page-number pagination used to cost ~75s of backoff before failing.
+        const isRetryableStatus = (status: number | undefined): boolean =>
+            status === undefined || status >= 500 || status === 429;
+
+        const requestWithRetry = async (url: string, params?: Record<string, any>, retries = 5, delay = 5000): Promise<any> => {
             for (let attempt = 0; attempt < retries; attempt++) {
                 try {
                     // Only log on retries to reduce noise during pagination
                     if (attempt > 0) {
                         logger.debug(`GitHub API retry: ${url} (attempt ${attempt + 1}/${retries})`);
                     }
+                    // Callers need the response headers (Link) for cursor
+                    // pagination, so the whole response is returned.
                     const response = await axios.get(url, {
                         headers: {
                             Authorization: `token ${GITHUB_TOKEN}`,
                             Accept: 'application/vnd.github.v3+json',
                         },
-                        params,
+                        // Subsequent pages come from a Link URL that already
+                        // carries its query string — adding params would duplicate it
+                        ...(params && { params }),
                         timeout: 30000, // 30 second timeout
                     });
-                    return response.data;
+                    return response;
                 } catch (error: any) {
                     // Enhanced error logging for debugging
                     const errorDetails = {
@@ -320,6 +331,14 @@ export class Doc2Vec {
                             logger.error(`GitHub API returned 403 (not rate limit): ${error.message}`);
                             throw error;
                         }
+                    } else if (!isRetryableStatus(error.response?.status)) {
+                        // Deterministic failure (422, 404, 401, ...) — surface the
+                        // API's own message, which explains what to do instead.
+                        const apiMessage = error.response?.data?.message;
+                        logger.error(
+                            `GitHub API returned ${error.response.status} (not retryable): ${apiMessage || error.message}`
+                        );
+                        throw error;
                     } else {
                         // For non-403 errors, wait before retrying (exponential backoff)
                         if (attempt < retries - 1) {
@@ -336,25 +355,47 @@ export class Doc2Vec {
             throw new Error('Max retries reached');
         };
 
+        /**
+         * Walk every issue updated since `sinceDate` by following GitHub's
+         * `Link: rel="next"` cursor URLs.
+         *
+         * Page-number pagination (`?page=N`) cannot be used here: GitHub caps it
+         * on this endpoint and answers HTTP 422 ("Pagination with the page
+         * parameter is not supported for large datasets, please use cursor based
+         * pagination") once the offset grows past its limit. That limit is well
+         * below the size of a full-window rebuild on a busy repo, so page-based
+         * paging aborted the whole source and left the collection empty. The
+         * Link URL already contains the opaque `after=` cursor and is passed
+         * through verbatim.
+         */
         const fetchAllIssues = async (sinceDate: string): Promise<any[]> => {
             let issues: any[] = [];
-            let page = 1;
-            const perPage = 100;
+            // sort=updated&direction=asc makes the walk stable: results are
+            // ordered by the same field `since` filters on, so a page boundary
+            // can't shuffle items in or out mid-walk.
+            let url: string | null = GITHUB_API_URL;
+            let params: Record<string, any> | undefined = {
+                per_page: 100,
+                state: 'all',
+                since: sinceDate,
+                sort: 'updated',
+                direction: 'asc',
+            };
+            let page = 0;
 
-            while (true) {
+            while (url) {
+                page++;
                 // Log progress every 10 pages to reduce noise
                 if (page === 1 || page % 10 === 0) {
                     logger.debug(`Fetching issues page ${page}... (${issues.length} issues so far)`);
                 }
 
-                const data = await fetchWithRetry(GITHUB_API_URL, {
-                    per_page: perPage,
-                    page,
-                    state: 'all',
-                    since: sinceDate,
-                });
-
-                if (data.length === 0) break;
+                const response = await requestWithRetry(url, params);
+                const data = response.data;
+                if (!Array.isArray(data)) {
+                    logger.warn(`Unexpected non-array response while paginating issues for ${repo}; stopping the walk`);
+                    break;
+                }
 
                 // The `since` param already scopes results to issues whose
                 // updated_at is after sinceDate — i.e. anything created, closed,
@@ -364,20 +405,47 @@ export class Doc2Vec {
                 // dropped, leaving its status and comments permanently stale.
                 issues = issues.concat(data);
 
-                if (data.length < perPage) break;
-                page++;
+                const nextUrl = Utils.parseNextLink(response.headers?.link ?? response.headers?.Link);
+                // Guard against a server echoing the same cursor forever
+                if (!nextUrl || nextUrl === url) break;
+                url = nextUrl;
+                params = undefined; // the cursor URL is already fully-formed
             }
+
+            logger.info(`Fetched ${issues.length} issues/PRs for ${repo} across ${page} page(s)`);
             return issues;
         };
 
         const fetchIssueComments = async (issueNumber: number): Promise<any[]> => {
-            const url = `${GITHUB_API_URL}/${issueNumber}/comments`;
-            return await fetchWithRetry(url);
+            // GitHub returns 30 comments per page by default and paginates the
+            // rest behind Link headers; requesting the first page only silently
+            // truncated long discussions, so the stored chunks were missing the
+            // newest comments.
+            const comments: any[] = [];
+            let url: string | null = `${GITHUB_API_URL}/${issueNumber}/comments`;
+            let params: Record<string, any> | undefined = { per_page: 100 };
+
+            while (url) {
+                const response = await requestWithRetry(url, params);
+                if (!Array.isArray(response.data)) break;
+                comments.push(...response.data);
+
+                const nextUrl = Utils.parseNextLink(response.headers?.link ?? response.headers?.Link);
+                if (!nextUrl || nextUrl === url) break;
+                url = nextUrl;
+                params = undefined;
+            }
+            return comments;
         };
 
         const generateMarkdownForIssue = async (issue: any): Promise<string> => {
             const comments = await fetchIssueComments(issue.number);
-            let md = `# Issue #${issue.number}: ${issue.title}\n\n`;
+            // This endpoint returns both issues and pull requests; only PRs carry
+            // a `pull_request` object. Labelling every item "Issue #N" made
+            // retrieved PR chunks read as issues, so use the real kind.
+            const itemLabel = issue.pull_request ? 'PR' : 'Issue';
+            let md = `# ${itemLabel} #${issue.number}: ${issue.title}\n\n`;
+            md += `- **Type:** ${issue.pull_request ? 'Pull request' : 'Issue'}\n`;
             md += `- **Author:** ${issue.user.login}\n`;
             md += `- **State:** ${issue.state}\n`;
             md += `- **Created on:** ${new Date(issue.created_at).toDateString()}\n`;
@@ -395,6 +463,10 @@ export class Doc2Vec {
 
             return md;
         };
+
+        // Chunks that could not be stored (e.g. a rejected Qdrant upsert).
+        // Tallied across all issues and escalated once the walk completes.
+        let failedChunks = 0;
 
         // Process a single issue and store its chunks
         const processIssue = async (issue: any): Promise<void> => {
@@ -489,7 +561,11 @@ export class Doc2Vec {
                             logger.error(`Embedding failed for chunk: ${chunkId}`);
                         }
                     } catch (error) {
-                        logger.error(`Error processing chunk in Qdrant:`, error);
+                        // Keep going so one bad chunk can't cost the whole repo,
+                        // but remember it: the count is escalated below so the run
+                        // fails and the last-run date is not advanced.
+                        failedChunks++;
+                        logger.error(`Error processing chunk ${chunkId} for ${url} in Qdrant:`, error);
                     }
                 }
             }
@@ -505,9 +581,18 @@ export class Doc2Vec {
             await processIssue(issues[i]);
         }
 
+        // A chunk that failed to store is silent data loss, so refuse to advance
+        // the last-run date: the next run reprocesses this window instead of
+        // treating the gap as synced. Everything that did store is kept.
+        if (failedChunks > 0) {
+            throw new Error(
+                `${failedChunks} chunk(s) failed to store for ${repo}; not advancing the last-run date so the next run retries them`
+            );
+        }
+
         // Update the last run date in the database after processing all issues
         await DatabaseManager.updateLastRunDate(dbConnection, repo, logger, this.embeddingDimension, syncStartDate);
-        
+
         logger.info(`Successfully processed ${issues.length} issues`);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "doc2vec",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "doc2vec",
-            "version": "2.12.0",
+            "version": "2.12.1",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.1004.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "doc2vec",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "type": "commonjs",
     "description": "",
     "main": "dist/doc2vec.js",

--- a/tests/content-processor.test.ts
+++ b/tests/content-processor.test.ts
@@ -2197,6 +2197,36 @@ describe('ContentProcessor', () => {
                 expect(hasOverlap).toBe(true);
             }
         });
+
+        // A split boundary landing inside a surrogate pair used to emit chunks
+        // containing a lone surrogate. That body is invalid UTF-8, so Qdrant
+        // rejected the upsert ("lone leading surrogate in hex escape") and the
+        // chunk was silently dropped.
+        it('never emits a chunk containing a lone surrogate when splitting emoji-heavy content', async () => {
+            // Emoji at every offset maximises the chance of straddling a boundary
+            const emojiContent = '# Emoji Section\n\n' + 'padding 😀 text 🎉 more 👍 words '.repeat(600);
+            const chunks = await processor.chunkMarkdown(emojiContent, baseConfig, 'https://example.com/emoji');
+
+            expect(chunks.length).toBeGreaterThan(1);
+            for (const chunk of chunks) {
+                // isWellFormed() is false exactly when a lone surrogate is present
+                expect(chunk.content.isWellFormed?.() ?? true).toBe(true);
+                // And the content must survive a strict JSON round-trip
+                expect(() => JSON.parse(JSON.stringify({ c: chunk.content }))).not.toThrow();
+            }
+        });
+
+        it('strips a lone surrogate that arrives in the source content', async () => {
+            // A truncated pair straight from the upstream source, not the splitter
+            const content = '# Broken\n\nThis body has a stray half-emoji \ud83d in the middle.';
+            const chunks = await processor.chunkMarkdown(content, baseConfig, 'https://example.com/broken');
+
+            expect(chunks.length).toBeGreaterThan(0);
+            for (const chunk of chunks) {
+                expect(chunk.content.isWellFormed?.() ?? true).toBe(true);
+            }
+            expect(chunks[0].content).toContain('stray half-emoji');
+        });
     });
 
     // ─── chunkMarkdown safety valve ──────────────────────────────────

--- a/tests/doc2vec.test.ts
+++ b/tests/doc2vec.test.ts
@@ -147,15 +147,23 @@ vi.mock('../logger', () => {
     };
 });
 
-// Mock Utils
-vi.mock('../utils', () => ({
-    Utils: {
-        generateHash: vi.fn().mockReturnValue('mock-hash'),
-        isValidUuid: vi.fn().mockReturnValue(false),
-        hashToUuid: vi.fn().mockReturnValue('00000000-0000-0000-0000-000000000000'),
-        getUrlPrefix: vi.fn().mockReturnValue('https://example.com'),
-    },
-}));
+// Mock Utils. parseNextLink/stripLoneSurrogates/sliceSafe are pure string
+// helpers with their own unit tests, so delegate to the real implementations
+// rather than stubbing them — the pagination tests depend on real Link parsing.
+vi.mock('../utils', async (importOriginal) => {
+    const actual = await importOriginal() as any;
+    return {
+        Utils: {
+            generateHash: vi.fn().mockReturnValue('mock-hash'),
+            isValidUuid: vi.fn().mockReturnValue(false),
+            hashToUuid: vi.fn().mockReturnValue('00000000-0000-0000-0000-000000000000'),
+            getUrlPrefix: vi.fn().mockReturnValue('https://example.com'),
+            parseNextLink: actual.Utils.parseNextLink,
+            stripLoneSurrogates: actual.Utils.stripLoneSurrogates,
+            sliceSafe: actual.Utils.sliceSafe,
+        },
+    };
+});
 
 // ─── Import the class under test (AFTER mocks are set up) ────────────────────
 
@@ -1927,16 +1935,48 @@ sources:
             body: 'A long-standing bug.',
         };
 
+        // Single-page mock: no Link header, so the cursor walk stops after one page.
         function mockGitHubApi(issues: any[], comments: any[] = []) {
-            (axios.get as any).mockImplementation((url: string, opts?: any) => {
-                if (url.endsWith('/comments')) {
-                    return Promise.resolve({ data: comments });
+            (axios.get as any).mockImplementation((url: string) => {
+                if (url.includes('/comments')) {
+                    return Promise.resolve({ data: comments, headers: {} });
                 }
-                // Issues list: only page 1 carries data. Any page beyond the first
-                // returns empty so pagination terminates deterministically.
-                const page = opts?.params?.page ?? 1;
-                return Promise.resolve({ data: page === 1 ? issues : [] });
+                return Promise.resolve({ data: issues, headers: {} });
             });
+        }
+
+        /**
+         * Mock a paginated endpoint that only advertises `Link: rel="next"`
+         * cursors — requesting `?page=N` past the first page returns 422, which
+         * is how GitHub behaves on large result sets.
+         */
+        function mockCursorPaginatedApi(pages: any[][], comments: any[] = []) {
+            const requestedUrls: string[] = [];
+            (axios.get as any).mockImplementation((url: string, opts?: any) => {
+                if (url.includes('/comments')) {
+                    return Promise.resolve({ data: comments, headers: {} });
+                }
+                requestedUrls.push(url);
+
+                if (opts?.params?.page !== undefined || /[?&]page=/.test(url)) {
+                    const err: any = new Error('Request failed with status code 422');
+                    err.response = {
+                        status: 422,
+                        headers: {},
+                        data: { message: 'Pagination with the page parameter is not supported for large datasets, please use cursor based pagination (after/before)' },
+                    };
+                    return Promise.reject(err);
+                }
+
+                const cursorMatch = url.match(/after=cursor-(\d+)/);
+                const index = cursorMatch ? Number(cursorMatch[1]) : 0;
+                const isLast = index >= pages.length - 1;
+                return Promise.resolve({
+                    data: pages[index] ?? [],
+                    headers: isLast ? {} : { link: `<${issuesUrl}?per_page=100&after=cursor-${index + 1}>; rel="next"` },
+                });
+            });
+            return { requestedUrls };
         }
 
         it('processes an old issue closed since the last run (no created_at filtering)', async () => {
@@ -1976,6 +2016,210 @@ sources:
                 issueUrl(42),
                 expect.anything(),
             );
+        });
+
+        // ─── Cursor pagination ───────────────────────────────────────────
+        // GitHub caps page-number pagination on this endpoint and answers 422
+        // past its offset limit, which aborted the whole source and left the
+        // collection empty. The walk must follow Link: rel="next" instead.
+        describe('pagination', () => {
+            const makeIssue = (n: number) => ({
+                number: n,
+                title: `Issue ${n}`,
+                user: { login: 'alice' },
+                state: 'open',
+                created_at: '2025-02-01T00:00:00Z',
+                updated_at: '2025-02-02T00:00:00Z',
+                labels: [],
+                body: 'body',
+            });
+
+            it('follows Link rel="next" cursors across all pages', async () => {
+                const instance = makeInstance();
+                mockCursorPaginatedApi([
+                    [makeIssue(1), makeIssue(2)],
+                    [makeIssue(3)],
+                ]);
+
+                await instance.fetchAndProcessGitHubIssues(
+                    repo, { product_name: repo }, { type: 'sqlite', db: {} }, instance.logger,
+                );
+
+                // All three issues across both pages must be processed
+                const chunkedUrls = instance.contentProcessor.chunkMarkdown.mock.calls.map((c: any[]) => c[2]);
+                expect(chunkedUrls).toEqual([issueUrl(1), issueUrl(2), issueUrl(3)]);
+            });
+
+            it('never sends a page parameter (page-number paging is rejected past the cap)', async () => {
+                const instance = makeInstance();
+                mockCursorPaginatedApi([[makeIssue(1)]]);
+
+                await instance.fetchAndProcessGitHubIssues(
+                    repo, { product_name: repo }, { type: 'sqlite', db: {} }, instance.logger,
+                );
+
+                for (const call of (axios.get as any).mock.calls) {
+                    expect(call[1]?.params?.page).toBeUndefined();
+                }
+            });
+
+            it('requests a stable ordering so a mid-walk update cannot shuffle results', async () => {
+                const instance = makeInstance();
+                mockCursorPaginatedApi([[makeIssue(1)]]);
+
+                await instance.fetchAndProcessGitHubIssues(
+                    repo, { product_name: repo }, { type: 'sqlite', db: {} }, instance.logger,
+                );
+
+                const firstCall = (axios.get as any).mock.calls[0];
+                expect(firstCall[1].params).toMatchObject({ sort: 'updated', direction: 'asc', state: 'all' });
+            });
+
+            it('passes the cursor URL through verbatim without re-appending params', async () => {
+                const instance = makeInstance();
+                mockCursorPaginatedApi([[makeIssue(1)], [makeIssue(2)]]);
+
+                await instance.fetchAndProcessGitHubIssues(
+                    repo, { product_name: repo }, { type: 'sqlite', db: {} }, instance.logger,
+                );
+
+                const cursorCall = (axios.get as any).mock.calls.find((c: any[]) => c[0].includes('after=cursor-1'));
+                expect(cursorCall).toBeDefined();
+                // Re-adding params would duplicate the query string already in the URL
+                expect(cursorCall[1].params).toBeUndefined();
+            });
+
+            it('stops instead of looping when the next cursor repeats the current URL', async () => {
+                const instance = makeInstance();
+                (axios.get as any).mockImplementation((url: string) => {
+                    if (url.includes('/comments')) return Promise.resolve({ data: [], headers: {} });
+                    // Always advertises itself as the next page
+                    return Promise.resolve({ data: [makeIssue(1)], headers: { link: `<${url}>; rel="next"` } });
+                });
+
+                await instance.fetchAndProcessGitHubIssues(
+                    repo, { product_name: repo }, { type: 'sqlite', db: {} }, instance.logger,
+                );
+
+                expect(instance.contentProcessor.chunkMarkdown.mock.calls.length).toBe(1);
+            });
+
+            it('paginates issue comments instead of silently keeping only the first page', async () => {
+                const instance = makeInstance();
+                const commentsUrl = `${issuesUrl}/7/comments`;
+                (axios.get as any).mockImplementation((url: string, opts?: any) => {
+                    if (url.includes('/comments')) {
+                        if (url.includes('after=c2')) {
+                            return Promise.resolve({ data: [{ user: { login: 'carol' }, created_at: '2025-02-03T00:00:00Z', body: 'third' }], headers: {} });
+                        }
+                        return Promise.resolve({
+                            data: [{ user: { login: 'bob' }, created_at: '2025-02-02T00:00:00Z', body: 'second' }],
+                            headers: { link: `<${commentsUrl}?after=c2>; rel="next"` },
+                        });
+                    }
+                    return Promise.resolve({ data: [makeIssue(7)], headers: {} });
+                });
+
+                await instance.fetchAndProcessGitHubIssues(
+                    repo, { product_name: repo }, { type: 'sqlite', db: {} }, instance.logger,
+                );
+
+                const markdown = instance.contentProcessor.chunkMarkdown.mock.calls[0][0];
+                expect(markdown).toContain('second');
+                expect(markdown).toContain('third');
+            });
+        });
+
+        // ─── Retry classification ────────────────────────────────────────
+        describe('retry classification', () => {
+            function mockStatus(status: number, message = 'boom') {
+                (axios.get as any).mockImplementation(() => {
+                    const err: any = new Error(`Request failed with status code ${status}`);
+                    err.response = { status, headers: {}, data: { message } };
+                    return Promise.reject(err);
+                });
+            }
+
+            it('fails fast on 422 without burning retries', async () => {
+                const instance = makeInstance();
+                mockStatus(422, 'Pagination with the page parameter is not supported for large datasets');
+
+                await expect(instance.fetchAndProcessGitHubIssues(
+                    repo, { product_name: repo }, { type: 'sqlite', db: {} }, instance.logger,
+                )).rejects.toThrow('422');
+
+                // A deterministic failure must be attempted exactly once
+                expect((axios.get as any).mock.calls.length).toBe(1);
+            });
+
+            it('fails fast on 404', async () => {
+                const instance = makeInstance();
+                mockStatus(404, 'Not Found');
+
+                await expect(instance.fetchAndProcessGitHubIssues(
+                    repo, { product_name: repo }, { type: 'sqlite', db: {} }, instance.logger,
+                )).rejects.toThrow();
+                expect((axios.get as any).mock.calls.length).toBe(1);
+            });
+
+            it('still retries 500s', async () => {
+                const instance = makeInstance();
+                let attempts = 0;
+                (axios.get as any).mockImplementation((url: string) => {
+                    if (url.includes('/comments')) return Promise.resolve({ data: [], headers: {} });
+                    attempts++;
+                    if (attempts < 3) {
+                        const err: any = new Error('Request failed with status code 500');
+                        err.response = { status: 500, headers: {}, data: {} };
+                        return Promise.reject(err);
+                    }
+                    return Promise.resolve({ data: [], headers: {} });
+                });
+
+                await instance.fetchAndProcessGitHubIssues(
+                    repo, { product_name: repo }, { type: 'sqlite', db: {} }, instance.logger,
+                );
+
+                expect(attempts).toBe(3);
+            }, 30000);
+        });
+
+        // ─── Pull requests ───────────────────────────────────────────────
+        it('labels pull requests as PRs rather than issues', async () => {
+            const instance = makeInstance();
+            mockGitHubApi([{
+                number: 1915,
+                title: 'chore(deps): bump the go-minor-patch group',
+                user: { login: 'dependabot[bot]' },
+                state: 'open',
+                created_at: '2025-02-01T00:00:00Z',
+                updated_at: '2025-02-02T00:00:00Z',
+                labels: [],
+                body: 'bumps',
+                pull_request: { url: 'https://api.github.com/repos/octo/repo/pulls/1915' },
+            }]);
+
+            await instance.fetchAndProcessGitHubIssues(
+                repo, { product_name: repo }, { type: 'sqlite', db: {} }, instance.logger,
+            );
+
+            const markdown = instance.contentProcessor.chunkMarkdown.mock.calls[0][0];
+            expect(markdown).toContain('# PR #1915:');
+            expect(markdown).toContain('**Type:** Pull request');
+            expect(markdown).not.toContain('# Issue #1915:');
+        });
+
+        it('still labels plain issues as issues', async () => {
+            const instance = makeInstance();
+            mockGitHubApi([oldButRecentlyClosedIssue]);
+
+            await instance.fetchAndProcessGitHubIssues(
+                repo, { product_name: repo }, { type: 'sqlite', db: {} }, instance.logger,
+            );
+
+            const markdown = instance.contentProcessor.chunkMarkdown.mock.calls[0][0];
+            expect(markdown).toContain('# Issue #42:');
+            expect(markdown).toContain('**Type:** Issue');
         });
     });
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -363,4 +363,117 @@ describe('Utils', () => {
             expect(uuid).toMatch(/^[a-f0-9]{8}-[a-f0-9]{4}-5[a-f0-9]{3}-8[a-f0-9]{3}-[a-f0-9]{12}$/);
         });
     });
+    // ─── parseNextLink ──────────────────────────────────────────────
+    // GitHub caps page-number pagination on the issues endpoint (HTTP 422 past
+    // its offset limit), so following these cursor URLs is the only way to walk
+    // a large result set.
+    describe('parseNextLink', () => {
+        it('extracts the rel="next" URL', () => {
+            const header = '<https://api.github.com/repositories/1/issues?per_page=100&after=CURSOR>; rel="next"';
+            expect(Utils.parseNextLink(header))
+                .toBe('https://api.github.com/repositories/1/issues?per_page=100&after=CURSOR');
+        });
+
+        it('picks next out of a multi-rel header', () => {
+            const header = '<https://api.example/prev>; rel="prev", <https://api.example/next>; rel="next", <https://api.example/last>; rel="last"';
+            expect(Utils.parseNextLink(header)).toBe('https://api.example/next');
+        });
+
+        it('returns null when there is no next page', () => {
+            const header = '<https://api.example/first>; rel="first", <https://api.example/prev>; rel="prev"';
+            expect(Utils.parseNextLink(header)).toBeNull();
+        });
+
+        it('returns null for empty, undefined or null headers', () => {
+            expect(Utils.parseNextLink(undefined)).toBeNull();
+            expect(Utils.parseNextLink(null)).toBeNull();
+            expect(Utils.parseNextLink('')).toBeNull();
+        });
+
+        it('preserves the cursor query string verbatim', () => {
+            const url = 'https://api.github.com/repositories/74175805/issues?per_page=100&state=all&since=2024-01-01T00%3A00%3A00Z&after=Y3Vyc29yOnYyOpLPAAAB';
+            expect(Utils.parseNextLink(`<${url}>; rel="next"`)).toBe(url);
+        });
+    });
+
+    // ─── stripLoneSurrogates ────────────────────────────────────────
+    // A lone surrogate is invalid UTF-8, so Qdrant rejects the whole JSON body
+    // ("lone leading surrogate in hex escape") and the chunk is lost.
+    describe('stripLoneSurrogates', () => {
+        it('removes a lone high surrogate', () => {
+            const text = 'before \ud83d after';
+            const cleaned = Utils.stripLoneSurrogates(text);
+            expect(cleaned).toBe('before  after');
+            expect(cleaned.isWellFormed?.()).not.toBe(false);
+        });
+
+        it('removes a lone low surrogate', () => {
+            const cleaned = Utils.stripLoneSurrogates('before \ude00 after');
+            expect(cleaned).toBe('before  after');
+            expect(cleaned.isWellFormed?.()).not.toBe(false);
+        });
+
+        it('keeps valid surrogate pairs intact', () => {
+            const emoji = 'ok \ud83d\ude00 done';
+            expect(Utils.stripLoneSurrogates(emoji)).toBe(emoji);
+        });
+
+        it('keeps plain text unchanged', () => {
+            expect(Utils.stripLoneSurrogates('plain ascii + accents éàü + 日本語')).toBe('plain ascii + accents éàü + 日本語');
+        });
+
+        it('handles a lone surrogate adjacent to a valid pair', () => {
+            const cleaned = Utils.stripLoneSurrogates('\ud83d\ud83d\ude00');
+            expect(cleaned).toBe('\ud83d\ude00');
+            expect(cleaned.isWellFormed?.()).not.toBe(false);
+        });
+
+        it('produces JSON-safe output for content that broke the upsert', () => {
+            const broken = 'x'.repeat(10) + '\ud83d';
+            expect(JSON.parse(JSON.stringify({ c: Utils.stripLoneSurrogates(broken) })).c).toBe('x'.repeat(10));
+        });
+    });
+
+    // ─── sliceSafe ──────────────────────────────────────────────────
+    // The chunker splits oversized sections by character offset; a boundary
+    // landing inside a surrogate pair used to emit two broken chunks.
+    describe('sliceSafe', () => {
+        it('never splits a surrogate pair at the end boundary', () => {
+            // Pair straddles index 4/5
+            const text = 'abcd\ud83d\ude00efg';
+            const slice = Utils.sliceSafe(text, 0, 5);
+            expect(slice).toBe('abcd');
+            expect(slice.isWellFormed?.()).not.toBe(false);
+        });
+
+        it('picks up the whole pair the previous slice left behind', () => {
+            const text = 'abcd\ud83d\ude00efg';
+            // Index 5 is the low half; the slice steps back so the pair is intact
+            const slice = Utils.sliceSafe(text, 5, text.length);
+            expect(slice).toBe('\ud83d\ude00efg');
+            expect(slice.isWellFormed?.()).not.toBe(false);
+        });
+
+        it('behaves like slice when no pair is straddled', () => {
+            expect(Utils.sliceSafe('hello world', 0, 5)).toBe('hello');
+            expect(Utils.sliceSafe('hello world', 6, 11)).toBe('world');
+        });
+
+        it('keeps a pair whole when it sits fully inside the range', () => {
+            const text = 'ab\ud83d\ude00cd';
+            expect(Utils.sliceSafe(text, 0, text.length)).toBe(text);
+        });
+
+        it('clamps out-of-range bounds', () => {
+            expect(Utils.sliceSafe('abc', -5, 99)).toBe('abc');
+        });
+
+        it('reassembles the original text when slicing contiguously across a pair', () => {
+            const text = 'aaaa\ud83d\ude00bbbb';
+            const first = Utils.sliceSafe(text, 0, 5);
+            const second = Utils.sliceSafe(text, 5, text.length);
+            expect(first + second).toBe(text);
+            expect((first + second).isWellFormed?.()).not.toBe(false);
+        });
+    });
 });

--- a/utils.ts
+++ b/utils.ts
@@ -89,4 +89,63 @@ export class Utils {
         return text.split(/(\s+)/).filter(token => token.length > 0);
     }
 
-} 
+    /**
+     * Extract the `rel="next"` URL from an RFC 5988 Link header.
+     *
+     * GitHub's list endpoints cap page-number pagination (`?page=N`) and reject
+     * deeper offsets with HTTP 422 ("please use cursor based pagination"), so
+     * walking a large result set requires following these URLs — they already
+     * carry the opaque `after=` cursor and must be passed through verbatim
+     * rather than rebuilt from parts.
+     */
+    static parseNextLink(linkHeader: string | undefined | null): string | null {
+        if (!linkHeader) return null;
+        for (const part of linkHeader.split(',')) {
+            const match = part.match(/<([^>]+)>\s*;\s*rel\s*=\s*"?next"?/i);
+            if (match) return match[1].trim();
+        }
+        return null;
+    }
+
+    /**
+     * Drop unpaired UTF-16 surrogates.
+     *
+     * A lone surrogate is not valid UTF-8, so strict JSON parsers reject the
+     * whole request body — Qdrant answers 400 "lone leading surrogate in hex
+     * escape" and the chunk is lost. Content can arrive this way from an
+     * upstream source, so sanitize before storing.
+     */
+    static stripLoneSurrogates(text: string): string {
+        // Node 20+ exposes toWellFormed(), which replaces lone surrogates with
+        // U+FFFD. Removing them outright keeps the text closer to the original.
+        return text
+            .replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/g, '')
+            .replace(/(^|[^\uD800-\uDBFF])([\uDC00-\uDFFF])/g, '$1');
+    }
+
+    /**
+     * Slice a string without splitting a surrogate pair.
+     *
+     * Plain `slice()` works on UTF-16 code units, so a boundary landing inside
+     * a pair (emoji, some CJK) leaves a lone surrogate on each side. Both
+     * boundaries are nudged the same way — a straddled pair always travels with
+     * the *following* slice — so consecutive slices stay lossless: no pair falls
+     * into the gap between them, and none is duplicated.
+     */
+    static sliceSafe(text: string, start: number, end: number): string {
+        const isHigh = (code: number) => code >= 0xd800 && code <= 0xdbff;
+        const isLow = (code: number) => code >= 0xdc00 && code <= 0xdfff;
+        // True when the pair straddling `index` must move to the next slice
+        const straddles = (index: number) =>
+            index > 0 && index < text.length && isHigh(text.charCodeAt(index - 1)) && isLow(text.charCodeAt(index));
+
+        let from = Math.max(0, Math.min(start, text.length));
+        let to = Math.max(from, Math.min(text.length, end));
+        // Step back to pick up the high half the previous slice left behind
+        if (straddles(from)) from--;
+        // Leave the whole pair for the next slice
+        if (to > from && straddles(to)) to--;
+        return text.slice(from, to);
+    }
+
+}


### PR DESCRIPTION
## The incident

Full-window GitHub issue syncs aborted and left the Qdrant collection empty, and **could not recover on their own**. The last-run date is stored as a metadata point *inside* the collection being synced, so an empty collection reports "no saved run date", falls back to the configured `start_date`, produces the same oversized window, and fails identically every night.

Observed on `github-istio` and `github-gloo-mesh-enterprise` (both at 0 points).

## Root cause, and a correction to the ">10 000 issues" theory

GitHub caps page-number pagination (`?page=N`) on the issues endpoint and answers HTTP 422 past its offset limit:

> `Pagination with the page parameter is not supported for large datasets, please use cursor based pagination (after/before)`

The initial diagnosis put that wall at ~10 000 results. Measured against the live API, **the cap is offset 1000, independent of `per_page`**:

| request | offset | result |
|---|---:|---|
| `per_page=100&page=10` | 1000 | 200 ✅ |
| `per_page=100&page=11` | 1100 | **422** ❌ |
| `per_page=50&page=20` | 1000 | 200 ✅ |
| `per_page=50&page=21` | 1050 | **422** ❌ |

A `start_date` of `2025-08-27` — an 11-month window, nowhere near 10 000 items — still fails. GitHub's threshold does appear to vary (production logs show page 100 succeeding at 9 900 items authenticated; the table above was measured unauthenticated), but the practical consequence is worse than a 10 000 ceiling implies: repos sitting at 2 000–5 000 items in their window are **not** safely under the limit, and any of them becomes unrecoverable the moment its collection is emptied.

There is no volume-based workaround. Cursor pagination is the fix.

## Changes

- **Cursor pagination.** Follow GitHub's `Link: rel="next"` URLs instead of building `?page=N`. The URLs are passed through verbatim because they carry the opaque `after=` cursor. Requests now also use `sort=updated&direction=asc` so the walk is stable against mid-walk updates (and so checkpointing becomes possible later).
- **Terminal 4xx.** 422/404/401 fail immediately instead of consuming five attempts and ~75s of exponential backoff before failing anyway. 5xx, 429 and rate-limited 403s stay retryable.
- **Surrogate-safe chunking.** Fixed at the root cause: the oversized-section splitter sliced on UTF-16 *code units*, so a surrogate pair straddling a chunk boundary broke in half. A lone surrogate is invalid UTF-8, so Qdrant rejected the upsert (`lone leading surrogate in hex escape`) and the chunk was dropped while the run reported success. New `Utils.sliceSafe` keeps pairs whole; `Utils.stripLoneSurrogates` sanitizes defensively before the chunk id is derived from the text.
- **Failed stores now fail the source.** The swallowing `catch` is what made the above invisible. Chunks still upsert as they go, so one bad chunk degrades a run instead of emptying a collection — and the last-run date is not advanced over the gap, so the next run retries it.
- **Issue comments are paginated.** GitHub serves 30 per page by default; long discussions were silently truncated to their *oldest* comments. (Same class of bug as the Zendesk comment pagination fixed in #96.)
- **Pull requests are labelled as PRs.** This endpoint returns issues and PRs — PRs are wanted in the index — but calling every item `Issue #N` made retrieved PR chunks read incorrectly. Now `PR #N` with an explicit `**Type:**` line.

## Verification

Cursor walk against the live API using the shipped `Utils.parseNextLink`, with the exact request shape the fixed code issues:

```
page 10: 1000 items (offset 1000) next=yes
page 25: 2500 items (offset 2500) next=yes
RESULT: walked 25 pages, 2500 items using Utils.parseNextLink cursors
```

Straight past the offset-1000 wall, still advertising `next=yes` where the old code got its 422 (stopped at 25 pages to respect the unauthenticated rate limit).

Test suite: **651 passed**. New coverage for cursor following, absence of any `page` param, verbatim cursor pass-through, repeated-cursor loop guard, comment pagination, fail-fast on 422/404, continued retrying of 5xx, PR-vs-issue labelling, and `Utils.parseNextLink` / `stripLoneSurrogates` / `sliceSafe` — including an end-to-end check that emoji-heavy content never yields a chunk that fails a strict JSON round-trip.

## Deploy notes

`github-istio` and `github-gloo-mesh-enterprise` need **one manual run** after this ships — they are at 0 points and the nightly schedule alone would just re-fail before the fix reaches them. Expect both to be substantially larger than any current collection (roughly 20 500 and 11 000 items, issues + PRs), so worth watching disk on the Qdrant node.

Deferred items (structured `item_type` payload field, partial-progress checkpointing, blue/green collection rebuilds, dependency-bump PR noise, controller log API pagination) are recorded in `TODO.md` rather than implemented here. Notably `item_type` is a schema change across `DocumentChunk`, the SQLite vec0 table and the Qdrant payload, and cannot be backfilled without a full re-ingest — cheapest to decide before the next full rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)