### PR TITLE
fix(code): don't abandon a directory on a dangling symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,6 +767,12 @@ If you don't specify a config path, it will look for config.yaml in the current 
 
 ## Recent Changes
 
+### Code Scans: Dangling Symlinks and Incomplete Walks
+- **Dangling symlinks no longer abort a directory:** `statSync` follows symlinks, so a link whose target isn't in the clone (common in vendored forks, e.g. `crates/cel-fork/cel/README.md`) threw `ENOENT` and abandoned every remaining entry in that directory. Broken entries are now skipped with a warning and the walk continues
+- **Incomplete scans never delete chunks:** if a directory genuinely can't be listed, the scan is reported as incomplete — obsolete-file cleanup, the tracked-file list, the last-mtime marker, and the last-synced git SHA are all skipped, so unscanned files keep their chunks and the next run rescans them
+- **Incomplete scans fail the source:** a partial ingest is reported as a failed source instead of a silent success
+- **Quieter crawls:** planned browser restarts (initial launch, the every-50-pages recycle) log at `info`; only unplanned restarts (disconnected or degraded browser) warn
+
 ### Searchable Controller Run Logs
 - **Server-side log filtering:** Level chips and the keyword filter now query Postgres instead of the browser's in-memory buffer, so errors and warnings from the start of a long run are reachable (`GET /api/runs/:id/logs?levels=error,warn&q=...`, paged with **Load 2,000 more**)
 - **Whole-run level counts:** New `GET /api/runs/:id/logs/counts` endpoint backs the level chips, which previously only counted the lines still held in the browser

--- a/content-processor.ts
+++ b/content-processor.ts
@@ -34,6 +34,22 @@ export class BrowserLaunchError extends Error {
 }
 
 /**
+ * Outcome of walking a code source's directory tree.
+ *
+ * `incomplete` means at least one directory could not be listed, so the set of
+ * files the caller saw is only a subset of what is on disk. Callers must not
+ * treat the unseen files as deleted: cleanup and last-scanned markers have to
+ * be skipped, otherwise a transient I/O error silently purges chunks and the
+ * next run never revisits those files.
+ */
+export interface CodeScanResult {
+    processedFiles: number;
+    skippedFiles: number;
+    maxMtime: number;
+    incomplete: boolean;
+}
+
+/**
  * Resolve which browser binary to launch, in order of preference:
  *  1. PUPPETEER_EXECUTABLE_PATH (explicit override)
  *  2. Puppeteer's own downloaded Chrome for Testing (version-matched, the
@@ -500,8 +516,12 @@ export class ContentProcessor {
         // Restart the browser every N pages to prevent memory accumulation
         const PAGES_BETWEEN_RESTARTS = 50;
 
-        const restartBrowser = async (reason: string): Promise<void> => {
-            logger.warn(`Restarting browser: ${reason}`);
+        // Planned restarts (first launch, the every-N-pages recycle) are routine
+        // and would otherwise dominate a crawl's warning count; only unplanned
+        // ones — a disconnected or degraded browser — deserve a warning.
+        const restartBrowser = async (reason: string, planned = false): Promise<void> => {
+            if (planned) logger.info(`Restarting browser: ${reason}`);
+            else logger.warn(`Restarting browser: ${reason}`);
             if (browser) {
                 try { await browser.close(); } catch { /* ignore close errors on a degraded browser */ }
             }
@@ -522,10 +542,10 @@ export class ContentProcessor {
                 const reason = needsBrowserRestart
                     ? `protocol errors persisting after page recreation (${consecutiveProtocolErrors} consecutive)`
                     : browser ? 'browser disconnected' : 'initial launch';
-                await restartBrowser(reason);
+                await restartBrowser(reason, !browser && !needsBrowserRestart);
             } else if (pagesSinceRestart >= PAGES_BETWEEN_RESTARTS) {
                 // Periodic restart to prevent memory accumulation from long crawls
-                await restartBrowser(`periodic restart after ${pagesSinceRestart} pages`);
+                await restartBrowser(`periodic restart after ${pagesSinceRestart} pages`, true);
             } else if (pageNeedsRecreation) {
                 // The previous page.evaluate or navigation timed out / errored.
                 // Close the stale page and create a fresh one to avoid corrupted state.
@@ -1695,8 +1715,18 @@ export class ContentProcessor {
             
             for (const file of files) {
                 const filePath = path.join(dirPath, file);
-                const stat = fs.statSync(filePath);
-                
+
+                // A dangling symlink makes statSync throw ENOENT; skip the
+                // entry rather than abandoning the rest of the directory
+                let stat: fs.Stats;
+                try {
+                    stat = fs.statSync(filePath);
+                } catch (error) {
+                    logger.warn(`Skipping unreadable entry ${filePath}:`, error);
+                    skippedFiles++;
+                    continue;
+                }
+
                 // Skip already visited paths
                 if (visitedPaths.has(filePath)) {
                     logger.debug(`Skipping already visited path: ${filePath}`);
@@ -1790,7 +1820,7 @@ export class ContentProcessor {
             mtimeCutoff?: number;
             trackFiles?: Set<string>;
         }
-    ): Promise<{ processedFiles: number; skippedFiles: number; maxMtime: number }> {
+    ): Promise<CodeScanResult> {
         const logger = parentLogger.child('code-directory-processor');
         logger.info(`Processing code directory: ${dirPath}`);
 
@@ -1808,6 +1838,8 @@ export class ContentProcessor {
 
         let maxMtime = 0;
 
+        let incomplete = false;
+
         try {
             const files = fs.readdirSync(dirPath);
             let processedFiles = 0;
@@ -1819,7 +1851,19 @@ export class ContentProcessor {
 
             for (const file of files) {
                 const filePath = path.join(dirPath, file);
-                const stat = fs.statSync(filePath);
+
+                // statSync follows symlinks, so a dangling one (common in
+                // vendored forks) throws ENOENT. Skipping the entry keeps the
+                // rest of the directory — letting it throw used to abandon
+                // every sibling after it, and cleanup then deleted their chunks.
+                let stat: fs.Stats;
+                try {
+                    stat = fs.statSync(filePath);
+                } catch (error) {
+                    logger.warn(`Skipping unreadable entry ${filePath}:`, error);
+                    skippedFiles++;
+                    continue;
+                }
 
                 if (visitedPaths.has(filePath)) {
                     logger.debug(`Skipping already visited path: ${filePath}`);
@@ -1841,6 +1885,7 @@ export class ContentProcessor {
                         processedFiles += childResult.processedFiles;
                         skippedFiles += childResult.skippedFiles;
                         maxMtime = Math.max(maxMtime, childResult.maxMtime);
+                        incomplete = incomplete || childResult.incomplete;
                     } else {
                         logger.debug(`Skipping directory ${filePath} (recursive=false)`);
                     }
@@ -1891,10 +1936,13 @@ export class ContentProcessor {
             }
 
             logger.info(`Code directory processed. Processed: ${processedFiles}, Skipped: ${skippedFiles}`);
-            return { processedFiles, skippedFiles, maxMtime };
+            return { processedFiles, skippedFiles, maxMtime, incomplete };
         } catch (error) {
+            // The directory could not be listed at all — report the scan as
+            // incomplete so the caller skips cleanup instead of treating every
+            // file under this path as deleted
             logger.error(`Error reading code directory ${dirPath}:`, error);
-            return { processedFiles: 0, skippedFiles: 0, maxMtime };
+            return { processedFiles: 0, skippedFiles: 0, maxMtime, incomplete: true };
         }
     }
 

--- a/doc2vec.ts
+++ b/doc2vec.ts
@@ -1138,6 +1138,10 @@ export class Doc2Vec {
         let lastMtimeKey: string | undefined;
         let trackedFiles: Set<string> | undefined;
         let maxObservedMtime = 0;
+        // Set when a directory could not be listed: the files we saw are only a
+        // subset of what is on disk, so nothing may be treated as deleted and no
+        // "last scanned" marker may advance past this run
+        let scanIncomplete = false;
 
         if (config.source === 'local_directory') {
             if (!config.path) {
@@ -1240,13 +1244,20 @@ export class Doc2Vec {
                 }
             );
 
+            scanIncomplete = scanResult.incomplete;
+            if (scanIncomplete) {
+                logger.error('Directory scan was incomplete — skipping cleanup so unscanned files keep their chunks');
+            }
+
             if (trackedFiles) {
                 maxObservedMtime = scanResult.maxMtime;
             }
         } finally {
             logger.section('CLEANUP');
 
-            if (incrementalMode) {
+            if (scanIncomplete) {
+                logger.warn('Skipping cleanup and last-scanned markers: the scan did not cover the whole tree');
+            } else if (incrementalMode) {
                 if (deleteUrls.length > 0) {
                     logger.info(`Cleaning up ${deleteUrls.length} deleted/renamed files`);
                     for (const url of deleteUrls) {
@@ -1304,7 +1315,9 @@ export class Doc2Vec {
                 this.counters.chunks_deleted += removed.chunks;
             }
 
-            if (config.source === 'github' && basePath && repoBranch) {
+            // Storing the SHA after an incomplete scan would make the next run
+            // diff from it and never revisit the files this run missed
+            if (config.source === 'github' && basePath && repoBranch && !scanIncomplete) {
                 const headSha = await this.getRepoHeadSha(basePath, logger);
                 if (headSha) {
                     const shaKey = this.buildCodeShaMetadataKey(config.repo as string, repoBranch);
@@ -1320,6 +1333,12 @@ export class Doc2Vec {
                     logger.warn(`Failed to remove temporary repo at ${tempDir}:`, error);
                 }
             }
+        }
+
+        // Fail the source rather than reporting a partial ingest as a success —
+        // the collection is still serving whatever it had for the unscanned files
+        if (scanIncomplete) {
+            throw new Error(`Code scan of ${basePath} was incomplete: at least one directory could not be read`);
         }
 
         logger.info(`Finished processing code source (${config.source})`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "doc2vec",
-    "version": "2.13.0",
+    "version": "2.13.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "doc2vec",
-            "version": "2.13.0",
+            "version": "2.13.1",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.1004.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "doc2vec",
-    "version": "2.13.0",
+    "version": "2.13.1",
     "type": "commonjs",
     "description": "",
     "main": "dist/doc2vec.js",

--- a/tests/content-processor.test.ts
+++ b/tests/content-processor.test.ts
@@ -680,6 +680,133 @@ describe('ContentProcessor', () => {
 
             expect(processed.length).toBe(0);
         });
+
+        // Vendored forks carry symlinks whose target isn't in the clone; statSync
+        // follows them and throws ENOENT. That used to abandon the rest of the
+        // directory, and cleanup then deleted the chunks of every skipped file.
+        it('should skip a dangling symlink and still process its siblings', async () => {
+            fs.writeFileSync(path.join(testDir, 'a-before.ts'), 'const a = 1;');
+            fs.symlinkSync(path.join(testDir, 'missing-target.ts'), path.join(testDir, 'b-broken.ts'));
+            fs.writeFileSync(path.join(testDir, 'c-after.ts'), 'const c = 3;');
+
+            const processed: string[] = [];
+            const result = await processor.processCodeDirectory(
+                testDir,
+                { ...codeConfig, path: testDir, include_extensions: ['.ts'] },
+                async (filePath) => { processed.push(filePath); },
+                testLogger
+            );
+
+            expect(processed.map(p => path.basename(p)).sort()).toEqual(['a-before.ts', 'c-after.ts']);
+            expect(result.processedFiles).toBe(2);
+            expect(result.incomplete).toBe(false);
+        });
+
+        it('should not report a dangling symlink in a subdirectory as incomplete', async () => {
+            const subDir = path.join(testDir, 'sub');
+            fs.mkdirSync(subDir);
+            fs.symlinkSync(path.join(subDir, 'gone.ts'), path.join(subDir, 'broken.ts'));
+            fs.writeFileSync(path.join(subDir, 'real.ts'), 'const x = 1;');
+
+            const result = await processor.processCodeDirectory(
+                testDir,
+                { ...codeConfig, path: testDir, include_extensions: ['.ts'] },
+                async () => {},
+                testLogger
+            );
+
+            expect(result.processedFiles).toBe(1);
+            expect(result.incomplete).toBe(false);
+        });
+
+        it('should report incomplete when a directory cannot be listed', async () => {
+            const result = await processor.processCodeDirectory(
+                path.join(testDir, 'does-not-exist'),
+                { ...codeConfig, path: testDir, include_extensions: ['.ts'] },
+                async () => {},
+                testLogger
+            );
+
+            expect(result.incomplete).toBe(true);
+            expect(result.processedFiles).toBe(0);
+        });
+
+        // chmod 000 doesn't stop root, so this can't assert anything in a
+        // root container (CI images often run as root)
+        const runningAsRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+        it.skipIf(runningAsRoot)('should propagate incomplete from a subdirectory that cannot be listed', async () => {
+            const subDir = path.join(testDir, 'unreadable');
+            fs.mkdirSync(subDir);
+            fs.writeFileSync(path.join(subDir, 'hidden.ts'), 'code');
+            fs.writeFileSync(path.join(testDir, 'visible.ts'), 'code');
+            fs.chmodSync(subDir, 0o000);
+
+            try {
+                const result = await processor.processCodeDirectory(
+                    testDir,
+                    { ...codeConfig, path: testDir, include_extensions: ['.ts'] },
+                    async () => {},
+                    testLogger
+                );
+
+                expect(result.incomplete).toBe(true);
+                // the readable sibling is still ingested
+                expect(result.processedFiles).toBe(1);
+            } finally {
+                fs.chmodSync(subDir, 0o755);
+            }
+        });
+
+        it('should report a complete scan as complete', async () => {
+            fs.writeFileSync(path.join(testDir, 'ok.ts'), 'code');
+
+            const result = await processor.processCodeDirectory(
+                testDir,
+                { ...codeConfig, path: testDir, include_extensions: ['.ts'] },
+                async () => {},
+                testLogger
+            );
+
+            expect(result.incomplete).toBe(false);
+        });
+    });
+
+    // ─── processDirectory: dangling symlinks ────────────────────────
+    describe('processDirectory with a dangling symlink', () => {
+        const testDir = path.join(__dirname, '__test_symlink_dir__');
+
+        beforeEach(() => {
+            if (fs.existsSync(testDir)) fs.rmSync(testDir, { recursive: true });
+            fs.mkdirSync(testDir, { recursive: true });
+        });
+
+        afterEach(() => {
+            if (fs.existsSync(testDir)) fs.rmSync(testDir, { recursive: true });
+        });
+
+        it('should skip the broken link and process the remaining files', async () => {
+            fs.writeFileSync(path.join(testDir, 'a.md'), '# A');
+            fs.symlinkSync(path.join(testDir, 'nope.md'), path.join(testDir, 'b.md'));
+            fs.writeFileSync(path.join(testDir, 'c.md'), '# C');
+
+            const processed: string[] = [];
+            await processor.processDirectory(
+                testDir,
+                {
+                    type: 'local_directory',
+                    path: testDir,
+                    product_name: 'Test',
+                    version: '1.0',
+                    max_size: 100000,
+                    include_extensions: ['.md'],
+                    database_config: { type: 'sqlite', params: {} }
+                } as any,
+                async (filePath) => { processed.push(filePath); },
+                testLogger
+            );
+
+            expect(processed.map(p => path.basename(p)).sort()).toEqual(['a.md', 'c.md']);
+        });
     });
 
     // ─── isNetworkError (accessed via crawlWebsite behavior) ────────

--- a/tests/doc2vec.test.ts
+++ b/tests/doc2vec.test.ts
@@ -815,6 +815,60 @@ sources:
             });
         });
 
+        // An incomplete walk (a directory that couldn't be listed) means the set
+        // of files we saw is a subset of what's on disk. Treating that as the
+        // full picture deletes chunks for files that still exist.
+        describe('code source scan completeness', () => {
+            function makeLogger(): any {
+                const l: any = {
+                    info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+                    debug: vi.fn(), section: vi.fn(), event: vi.fn(),
+                };
+                l.child = vi.fn(() => makeLogger());
+                return l;
+            }
+
+            const codeConfig = {
+                type: 'code',
+                product_name: 'TestCode',
+                version: 'v1.0',
+                source: 'local_directory',
+                path: '/code',
+                max_size: 50000,
+                database_config: { type: 'sqlite', params: { db_path: ':memory:' } },
+            } as any;
+
+            it('runs cleanup when the scan covered the whole tree', async () => {
+                const { DatabaseManager } = await import('../database');
+                instance = createInstanceWithSources([codeConfig]);
+                (instance as any).contentProcessor.processCodeDirectory = vi.fn().mockResolvedValue({
+                    processedFiles: 3, skippedFiles: 0, maxMtime: 123, incomplete: false,
+                });
+
+                await (instance as any).processCodeSource(codeConfig, makeLogger());
+
+                expect(DatabaseManager.setMetadataValue).toHaveBeenCalled();
+            });
+
+            it('skips cleanup and fails the source when the scan was incomplete', async () => {
+                const { DatabaseManager } = await import('../database');
+                instance = createInstanceWithSources([codeConfig]);
+                (instance as any).contentProcessor.processCodeDirectory = vi.fn().mockResolvedValue({
+                    processedFiles: 1, skippedFiles: 0, maxMtime: 123, incomplete: true,
+                });
+
+                await expect((instance as any).processCodeSource(codeConfig, makeLogger()))
+                    .rejects.toThrow(/incomplete/i);
+
+                // no chunk deletion of any kind
+                expect(DatabaseManager.removeObsoleteFilesSQLite).not.toHaveBeenCalled();
+                expect(DatabaseManager.removeObsoleteFilesQdrant).not.toHaveBeenCalled();
+                expect(DatabaseManager.removeChunksByUrlSQLite).not.toHaveBeenCalled();
+                // and no marker advances, so the next run rescans the whole tree
+                expect(DatabaseManager.setMetadataValue).not.toHaveBeenCalled();
+            });
+        });
+
         it('should route website source to processWebsite', async () => {
             instance = createInstanceWithSources([{
                 type: 'website',


### PR DESCRIPTION
Triaged from a production run's 4 errors — three of them were this one bug.

## The bug

`fs.statSync` follows symlinks, and it sat **outside** the per-file try/catch in both directory walkers. A symlink whose target isn't in the clone throws `ENOENT`, which unwound to the directory-level catch. Two such links were enough to break the agentgateway code sources:

```
Error reading code directory /tmp/doc2vec-code-pCEP1V/crates/cel-fork/cel:
  ENOENT: no such file or directory, stat '.../crates/cel-fork/cel/README.md'
```

`crates/cel-fork/cel/README.md` is `{"type":"symlink"}` in the repo (same for `ent-controller/install/helm/kgateway-crds`). Three consequences, in increasing order of severity:

1. **Every remaining entry in that directory was skipped** — the rest of the vendored CEL fork, everything after `kgateway-crds` in `install/helm/`.
2. **Their chunks were then deleted.** Skipped files never reach `processedFiles`, and the full-scan cleanup calls `removeObsoleteFiles*(processedFiles, …)` — so previously-indexed files were purged from the collection because an unrelated symlink was broken.
3. **The run reported success.** The error was swallowed; the source came back `ok`, exit code 0. Same class as the silent chunk loss fixed in #101.

## The fix

- Both walkers skip an entry they can't `stat`, with a warning, instead of aborting the directory.
- `processCodeDirectory` returns `CodeScanResult.incomplete` when a directory genuinely can't be listed (permissions, I/O), propagated up from child directories.
- An incomplete scan skips **every** step that assumes a full picture: obsolete-file cleanup, the tracked-file list, the last-mtime marker, and the last-synced git SHA. That last one mattered as much as the deletions — advancing it meant the next run diffed from that SHA and never revisited the missed files.
- An incomplete scan **fails the source** instead of reporting a partial ingest as a success.

The two parts compose: a dangling symlink no longer marks a scan incomplete (nothing was lost — the target doesn't exist), so repos that legitimately carry broken links don't start failing every run.

Also drops planned browser restarts (initial launch, the every-50-pages recycle) from `warn` to `info` — they accounted for most of the warnings on a long crawl. Unplanned restarts (disconnected or degraded browser) still warn.

## Tests

8 new tests against the real filesystem:

- dangling symlink mid-directory — siblings before *and* after are still processed
- broken link inside a subdirectory — scan still reports complete
- unlistable directory → `incomplete`, and propagation from a child while a readable sibling still ingests (skipped when running as root, where `chmod 000` doesn't apply)
- complete scan → not incomplete; same symlink coverage for the non-code walker
- caller-side: an incomplete scan performs no deletion, writes no metadata, and throws

Full suite passes (669 passed; skips are the Postgres-gated store tests plus 2 pre-existing).

## Not fixed here

- `ERR_TOO_MANY_REDIRECTS` on `helm.sh/docs/faq/` — a redirect loop on the remote site, caught per page, crawl continues. Nothing to fix on our side.
- Two agentgateway API-reference pages exceed `max_size: 1048576` in raw HTML (1.8 MB / 2.4 MB) and are skipped entirely — a config change on the deployment side, not code.

Version bumped to 2.13.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)