### PR TITLE
feat(controller): select individual sources for manual runs, sortable run sources table

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The primary goal is to prepare documentation content for Retrieval-Augmented Gen
 
 Run it two ways:
 
-*   **One-shot sync** — `doc2vec run config.yaml` processes every source in a config file and exits. Ideal for a cron job or CI step.
+*   **One-shot sync** — `doc2vec run config.yaml` processes every source in a config file and exits. Ideal for a cron job or CI step. Pass `--source <product_name>` (all entries with that name) or `--source-index <n>` (a single entry, by its 0-based position in the config) to sync only selected sources; both flags are repeatable.
 *   **[Controller mode](#controller-mode)** — `doc2vec controller ./configs/` stays running: it schedules each config on its own cron expression, keeps run history and per-source statistics in Postgres, and serves a web UI with live log streaming, searchable run logs, and chunk inspection. Deploy it once and manage all your sources from the browser.
 
 [![doc2vec controller dashboard](docs/images/controller-dashboard.png)](#controller-mode)
@@ -451,7 +451,7 @@ Besides the one-shot sync, doc2vec can run as a **long-lived controller** that s
 doc2vec controller --database-url postgres://user:pass@host:5432/doc2vec ./configs/
 ```
 
-Open http://localhost:8080 to see the dashboard ([screenshot above](#doc2vec)): every config with its schedule, next run, and the outcome of its last run, plus a **Run now** button.
+Open http://localhost:8080 to see the dashboard ([screenshot above](#doc2vec)): every config with its schedule, next run, and the outcome of its last run, plus a **Run now** button. The **▾** next to it opens a source picker to sync only a subset of the config's source entries — each entry is selectable individually, even when several share a product name (e.g. istio as github + code + website) — and the run history marks such partial runs with the selected sources.
 
 Each config gets its own page with the full run history, per-source results, and the raw YAML:
 
@@ -477,7 +477,7 @@ sources:
     ...
 ```
 
-Configs without a `schedule` are still listed in the UI and can be triggered manually with **Run now**. Each run executes `doc2vec run <config.yaml>` as a child process; overlapping runs of the same config are skipped, and `--max-parallel` (default 1) caps how many sync jobs run at once — keep it low, since website sources launch a headless Chromium.
+Configs without a `schedule` are still listed in the UI and can be triggered manually with **Run now** (optionally for a subset of sources via the **▾** picker). Each run executes `doc2vec run <config.yaml>` as a child process (with `--source-index <n>` flags when a subset was selected); overlapping runs of the same config are skipped, and `--max-parallel` (default 1) caps how many sync jobs run at once — keep it low, since website sources launch a headless Chromium.
 
 ### Logs
 

--- a/controller/job-runner.ts
+++ b/controller/job-runner.ts
@@ -4,7 +4,7 @@ import * as readline from 'readline';
 import { Logger } from '../logger';
 import { ControllerEvents } from './events';
 import { ControllerStore } from './store';
-import { ConfigRecord, ConflictError, LogRow, RunRecord, RunTrigger } from './types';
+import { ConfigRecord, ConflictError, LogRow, RequestedSource, RunRecord, RunTrigger } from './types';
 
 const MAX_LOG_MESSAGE_BYTES = 8192;
 const LOG_FLUSH_LINES = 100;
@@ -16,6 +16,7 @@ interface QueuedJob {
     runId: number;
     configId: number;
     configPath: string;
+    sources?: RequestedSource[];   // manual source selection; undefined = all sources
 }
 
 interface ActiveJob {
@@ -68,7 +69,7 @@ export class JobRunner {
         return this.active.size;
     }
 
-    async enqueue(config: ConfigRecord, trigger: RunTrigger): Promise<RunRecord> {
+    async enqueue(config: ConfigRecord, trigger: RunTrigger, sources?: RequestedSource[]): Promise<RunRecord> {
         if (this.shuttingDown) {
             throw new ConflictError('controller is shutting down');
         }
@@ -86,9 +87,9 @@ export class JobRunner {
             throw new ConflictError(`config is invalid: ${config.parse_error}`);
         }
 
-        const run = await this.store.createRun(config.id, config.content_hash, trigger, 'queued');
+        const run = await this.store.createRun(config.id, config.content_hash, trigger, 'queued', undefined, sources);
         this.queuedConfigs.add(config.id);
-        this.queue.push({ runId: run.id, configId: config.id, configPath: config.path });
+        this.queue.push({ runId: run.id, configId: config.id, configPath: config.path, sources });
         this.events.emitRunUpdate(run);
         this.pump();
         return run;
@@ -122,6 +123,9 @@ export class JobRunner {
 
     private async start(job: QueuedJob): Promise<void> {
         const { cmd, args } = this.commandFor(job.configPath);
+        for (const source of job.sources ?? []) {
+            args.push('--source-index', String(source.index));
+        }
         this.logger.info(`Starting run ${job.runId}: ${cmd} ${args.join(' ')}`);
 
         const child = spawn(cmd, args, {

--- a/controller/migrations.ts
+++ b/controller/migrations.ts
@@ -55,4 +55,10 @@ export const MIGRATIONS: string[] = [
     `
     CREATE INDEX IF NOT EXISTS d2v_run_logs_level_idx ON d2v_run_logs (run_id, level, seq);
     `,
+
+    // 3: manual runs can target a subset of a config's source entries (stored as
+    // [{index, product_name, type, version}]); NULL means the run covers all sources
+    `
+    ALTER TABLE d2v_runs ADD COLUMN IF NOT EXISTS requested_sources JSONB;
+    `,
 ];

--- a/controller/server.ts
+++ b/controller/server.ts
@@ -8,7 +8,7 @@ import { ControllerEvents } from './events';
 import { JobRunner } from './job-runner';
 import { Scheduler } from './scheduler';
 import { ControllerStore, LogFilter } from './store';
-import { ConflictError, LogRow, NotFoundError, RunRecord, RunStatus, ValidationError } from './types';
+import { ConflictError, LogRow, NotFoundError, RequestedSource, RunRecord, RunStatus, ValidationError } from './types';
 
 const SSE_HEARTBEAT_MS = 15_000;
 const LOG_PAGE_SIZE = 5000;
@@ -143,7 +143,33 @@ export function createServer(deps: ServerDeps): express.Express {
     app.post('/api/configs/:id/run', async (req, res) => {
         const config = registry.get(parseId(String(req.params.id)));
         if (!config) throw new NotFoundError('config not found');
-        const run = await runner.enqueue(config, 'manual');
+
+        // Optional source selection: 0-based positions in the config's sources
+        // list (exact — product names can repeat). Default: all sources.
+        let sources: RequestedSource[] | undefined;
+        const { sources: rawSources, baseHash } = (req.body ?? {}) as { sources?: unknown; baseHash?: unknown };
+        if (rawSources !== undefined) {
+            if (!Array.isArray(rawSources) || rawSources.some(i => !Number.isInteger(i))) {
+                throw new ValidationError('sources must be an array of source indices (integers)');
+            }
+            // Indices are only meaningful against the config revision the client
+            // saw — reject the run if the config changed underneath it.
+            if (baseHash !== undefined && baseHash !== config.content_hash) {
+                throw new ConflictError('config changed since the source list was loaded — reload and retry');
+            }
+            const total = config.source_summary.length;
+            const outOfRange = rawSources.filter((i: number) => i < 0 || i >= total);
+            if (outOfRange.length > 0) {
+                throw new ValidationError(`source index out of range: ${outOfRange.join(', ')} (config has ${total} sources)`);
+            }
+            // Deduplicate, keep config order; empty or full selection = full run
+            const indices = [...new Set(rawSources as number[])].sort((a, b) => a - b);
+            if (indices.length > 0 && indices.length < total) {
+                sources = indices.map(index => ({ index, ...config.source_summary[index] }));
+            }
+        }
+
+        const run = await runner.enqueue(config, 'manual', sources);
         res.status(202).json(run);
     });
 

--- a/controller/store.ts
+++ b/controller/store.ts
@@ -4,6 +4,7 @@ import { MIGRATIONS } from './migrations';
 import {
     ConfigRecord,
     LogRow,
+    RequestedSource,
     RunRecord,
     RunStatsPayload,
     RunStatus,
@@ -133,13 +134,13 @@ export class ControllerStore {
 
     // ------------------------------------------------------------------ runs
 
-    async createRun(configId: number, configHash: string, trigger: RunTrigger, status: RunStatus, error?: string): Promise<RunRecord> {
+    async createRun(configId: number, configHash: string, trigger: RunTrigger, status: RunStatus, error?: string, requestedSources?: RequestedSource[]): Promise<RunRecord> {
         const terminal = status === 'skipped';
         const { rows } = await this.pool.query(
-            `INSERT INTO d2v_runs (config_id, config_hash, trigger, status, error, finished_at)
-             VALUES ($1, $2, $3, $4, $5, ${terminal ? 'NOW()' : 'NULL'})
+            `INSERT INTO d2v_runs (config_id, config_hash, trigger, status, error, requested_sources, finished_at)
+             VALUES ($1, $2, $3, $4, $5, $6, ${terminal ? 'NOW()' : 'NULL'})
              RETURNING *`,
-            [configId, configHash, trigger, status, error ?? null]
+            [configId, configHash, trigger, status, error ?? null, requestedSources?.length ? JSON.stringify(requestedSources) : null]
         );
         return rows[0];
     }

--- a/controller/types.ts
+++ b/controller/types.ts
@@ -36,6 +36,16 @@ export interface ConfigRecord {
 }
 
 export type RunTrigger = 'scheduled' | 'manual';
+
+/** One config source entry targeted by a partial manual run. `index` is the
+ *  position in the config's sources list — the only unambiguous identifier,
+ *  since product names (even with type and version) can repeat. */
+export interface RequestedSource {
+    index: number;
+    product_name: string;
+    type: string;
+    version?: string;
+}
 export type RunStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'skipped' | 'canceled';
 
 export interface RunRecord {
@@ -47,6 +57,7 @@ export interface RunRecord {
     pid: number | null;
     exit_code: number | null;
     error: string | null;
+    requested_sources: RequestedSource[] | null;  // manual source selection; null = all sources
     stats: RunStatsPayload;
     queued_at: string;
     started_at: string | null;

--- a/doc2vec.ts
+++ b/doc2vec.ts
@@ -180,7 +180,34 @@ export class Doc2Vec {
         return parsedValue;
     }
 
-    public async run(): Promise<SourceRunStats[]> {
+    /**
+     * Sync sources sequentially. An optional selection restricts the run to a
+     * subset of the config's sources: `indices` are 0-based positions in the
+     * config's sources list (exact — the only unambiguous identifier, since
+     * product names can repeat), and `names` match every source with that
+     * product_name. The union of both is processed, in config order.
+     */
+    public async run(selection?: { indices?: number[]; names?: string[] }): Promise<SourceRunStats[]> {
+        let sources = this.config.sources;
+        const wantedIndices = selection?.indices ?? [];
+        const wantedNames = selection?.names ?? [];
+        if (wantedIndices.length > 0 || wantedNames.length > 0) {
+            const badIndices = wantedIndices.filter(i => !Number.isInteger(i) || i < 0 || i >= this.config.sources.length);
+            if (badIndices.length > 0) {
+                throw new Error(`Source index out of range: ${badIndices.join(', ')} (config has ${this.config.sources.length} sources)`);
+            }
+            const known = new Set(this.config.sources.map(s => s.product_name));
+            const unknown = wantedNames.filter(name => !known.has(name));
+            if (unknown.length > 0) {
+                throw new Error(`Unknown source(s): ${unknown.join(', ')}. Available: ${[...known].join(', ')}`);
+            }
+            const nameSet = new Set(wantedNames);
+            const indexSet = new Set(wantedIndices);
+            sources = this.config.sources.filter((s, i) => indexSet.has(i) || nameSet.has(s.product_name));
+            const label = sources.map(s => `${s.product_name} (${s.type})`).join(', ');
+            this.logger.info(`Source filter active: syncing ${sources.length} of ${this.config.sources.length} sources: ${label}`);
+        }
+
         // Initialize Postgres markdown store table if configured
         if (this.markdownStore) {
             await this.markdownStore.init();
@@ -190,7 +217,7 @@ export class Doc2Vec {
 
         const runStats: SourceRunStats[] = [];
 
-        for (const sourceConfig of this.config.sources) {
+        for (const sourceConfig of sources) {
             const sourceLogger = this.logger.child(`source:${sourceConfig.product_name}`);
 
             sourceLogger.info(`Processing ${sourceConfig.type} source for ${sourceConfig.product_name}@${sourceConfig.version}`);
@@ -2041,15 +2068,15 @@ export class Doc2Vec {
     }
 }
 
-function runOneShot(configPath: string): void {
+function runOneShot(configPath: string, selection?: { indices?: number[]; names?: string[] }): void {
     if (!fs.existsSync(configPath)) {
         console.error('Please provide a valid path to a YAML config file.');
         process.exit(1);
     }
     const doc2Vec = new Doc2Vec(configPath);
-    doc2Vec.run()
+    doc2Vec.run(selection)
         .then((stats) => process.exit(stats.some(s => !s.ok) ? 1 : 0))
-        .catch((err) => { console.error(err); process.exit(1); });
+        .catch((err) => { console.error(err instanceof Error ? err.message : err); process.exit(1); });
 }
 
 if (require.main === module) {
@@ -2059,14 +2086,22 @@ if (require.main === module) {
     program
         .name('doc2vec')
         .description('Crawl documentation sources and store embeddings in vector databases')
-        // Legacy invocation: `doc2vec [config.yaml]` runs a one-shot sync
+        // Legacy invocation: `doc2vec [config.yaml]` runs a one-shot sync.
+        // The source-filter flags live only on the `run` subcommand: declaring
+        // them here too would swallow them at the program level before the
+        // subcommand's parser ever sees them.
         .argument('[config]', 'path to a YAML config file', 'config.yaml')
         .action((configPath: string) => runOneShot(configPath));
 
     program
         .command('run <config>')
         .description('Run a one-shot sync for a config file (what the controller spawns)')
-        .action((configPath: string) => runOneShot(configPath));
+        .option('--source <product_name>', 'only sync sources with this product_name (repeatable)',
+            (value: string, previous: string[]) => [...previous, value], [] as string[])
+        .option('--source-index <n>', 'only sync the source at this 0-based position in the config (repeatable, exact)',
+            (value: string, previous: number[]) => [...previous, parseInt(value, 10)], [] as number[])
+        .action((configPath: string, options: { source: string[]; sourceIndex: number[] }) =>
+            runOneShot(configPath, { names: options.source, indices: options.sourceIndex }));
 
     program
         .command('controller [configs...]')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "doc2vec",
-    "version": "2.13.1",
+    "version": "2.14.0",
     "type": "commonjs",
     "description": "",
     "main": "dist/doc2vec.js",

--- a/tests/controller-runner.test.ts
+++ b/tests/controller-runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { JobRunner } from '../controller/job-runner';
-import { ConflictError, ConfigRecord, LogRow, RunRecord } from '../controller/types';
+import { ConflictError, ConfigRecord, LogRow, RequestedSource, RunRecord } from '../controller/types';
 
 function makeLogger(): any {
     const l: any = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), section: vi.fn(), event: vi.fn() };
@@ -34,7 +34,7 @@ function makeStore() {
     return {
         runs,
         logs,
-        createRun: vi.fn(async (configId: number, configHash: string, trigger: any, status: any, error?: string) => {
+        createRun: vi.fn(async (configId: number, configHash: string, trigger: any, status: any, error?: string, requestedSources?: RequestedSource[]) => {
             const run: RunRecord = {
                 id: nextRunId++,
                 config_id: configId,
@@ -44,6 +44,7 @@ function makeStore() {
                 pid: null,
                 exit_code: null,
                 error: error ?? null,
+                requested_sources: requestedSources ?? null,
                 stats: {},
                 queued_at: new Date().toISOString(),
                 started_at: null,
@@ -93,9 +94,13 @@ async function waitForRun(store: any, runId: number, timeoutMs = 10_000): Promis
     throw new Error(`run ${runId} did not finish in time (status: ${store.runs.get(runId)?.status})`);
 }
 
-/** commandFor stub: runs an inline node script instead of a real sync. */
+/**
+ * commandFor stub: runs an inline node script instead of a real sync. The
+ * trailing `--` makes node hand any appended flags (e.g. --source) to the
+ * script's argv, like a script-file invocation would.
+ */
 function inlineScript(script: string) {
-    return () => ({ cmd: process.execPath, args: ['-e', script] });
+    return () => ({ cmd: process.execPath, args: ['-e', script, '--'] });
 }
 
 describe('JobRunner', () => {
@@ -219,6 +224,34 @@ describe('JobRunner', () => {
         expect(finishedRunning.error).toBe('controller shutdown');
 
         await expect(runner.enqueue(makeConfig(3), 'manual')).rejects.toThrow(ConflictError);
+    });
+
+    it('passes a manual source selection to the spawned command and the run record', async () => {
+        // The inline script echoes its extra argv so we can assert the --source-index flags
+        const runner = makeRunner(`
+            console.log(JSON.stringify({ level: 'info', msg: 'argv: ' + process.argv.slice(1).join(' ') }));
+        `);
+        const selection = [
+            { index: 2, product_name: 'istio', type: 'code', version: 'master' },
+            { index: 7, product_name: 'argo', type: 'website', version: 'latest' },
+        ];
+        const run = await runner.enqueue(makeConfig(1), 'manual', selection);
+        expect(store.createRun).toHaveBeenCalledWith(1, 'hash-1', 'manual', 'queued', undefined, selection);
+        expect(run.requested_sources).toEqual(selection);
+
+        await waitForRun(store, run.id);
+        const logs = store.logs.get(run.id) ?? [];
+        expect(logs.some(l => l.message.includes('--source-index 2 --source-index 7'))).toBe(true);
+    });
+
+    it('spawns without --source-index flags when no selection is given', async () => {
+        const runner = makeRunner(`
+            console.log(JSON.stringify({ level: 'info', msg: 'argv: ' + process.argv.slice(1).join(' ') }));
+        `);
+        const run = await runner.enqueue(makeConfig(1), 'manual');
+        await waitForRun(store, run.id);
+        const logs = store.logs.get(run.id) ?? [];
+        expect(logs.some(l => l.message.includes('--source-index'))).toBe(false);
     });
 
     it('rejects runs for configs with parse errors', async () => {

--- a/tests/controller-server-run.test.ts
+++ b/tests/controller-server-run.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import * as http from 'http';
+import { createServer } from '../controller/server';
+import { Logger, LogLevel } from '../logger';
+
+const testLogger = new Logger('server-run-test', { level: LogLevel.NONE });
+
+let server: http.Server;
+let baseUrl: string;
+let enqueue: ReturnType<typeof vi.fn>;
+
+const CONFIG = {
+    id: 1,
+    name: 'cfg',
+    path: '/x/cfg.yaml',
+    content: '',
+    content_hash: 'hash-v1',
+    schedule: null,
+    parse_error: null,
+    enabled: true,
+    // 'istio' appears twice (two source entries sharing a product name)
+    source_summary: [
+        { type: 'website', product_name: 'istio', version: 'latest' },
+        { type: 'code', product_name: 'istio', version: 'master' },
+        { type: 'website', product_name: 'argo', version: 'latest' },
+        { type: 'github', product_name: 'cilium', version: 'latest' },
+    ],
+};
+
+function makeDeps(): any {
+    enqueue = vi.fn(async (_config: any, trigger: string, sources?: any[]) => ({
+        id: 42,
+        config_id: 1,
+        trigger,
+        status: 'queued',
+        requested_sources: sources ?? null,
+    }));
+    return {
+        store: { getLastRuns: async () => new Map() },
+        registry: { get: (id: number) => (id === 1 ? CONFIG : undefined), list: () => [CONFIG] },
+        scheduler: { nextRun: () => null },
+        runner: { isBusy: () => false, enqueue },
+        events: { on: () => {}, off: () => {} },
+        readWrite: false,
+        logger: testLogger,
+    };
+}
+
+beforeAll(async () => {
+    const app = createServer(makeDeps());
+    server = http.createServer(app);
+    await new Promise<void>(resolve => server.listen(0, resolve));
+    const address = server.address() as { port: number };
+    baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+    await new Promise<void>((resolve, reject) => server.close(err => (err ? reject(err) : resolve())));
+});
+
+beforeEach(() => {
+    enqueue.mockClear();
+});
+
+async function triggerRun(body?: unknown): Promise<Response> {
+    return fetch(`${baseUrl}/api/configs/1/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        ...(body !== undefined && { body: JSON.stringify(body) }),
+    });
+}
+
+describe('POST /api/configs/:id/run', () => {
+    it('enqueues a full run when no sources are given', async () => {
+        const res = await triggerRun();
+        expect(res.status).toBe(202);
+        expect(enqueue).toHaveBeenCalledWith(CONFIG, 'manual', undefined);
+    });
+
+    it('enqueues a partial run resolving indices to source entries, deduplicated and in config order', async () => {
+        const res = await triggerRun({ sources: [2, 1, 2], baseHash: 'hash-v1' });
+        expect(res.status).toBe(202);
+        expect(enqueue).toHaveBeenCalledWith(CONFIG, 'manual', [
+            { index: 1, type: 'code', product_name: 'istio', version: 'master' },
+            { index: 2, type: 'website', product_name: 'argo', version: 'latest' },
+        ]);
+        const run = await res.json();
+        expect(run.requested_sources.map((s: any) => s.index)).toEqual([1, 2]);
+    });
+
+    it('distinguishes entries that share a product name', async () => {
+        const res = await triggerRun({ sources: [1] });
+        expect(res.status).toBe(202);
+        const [, , sources] = enqueue.mock.calls[0];
+        expect(sources).toEqual([{ index: 1, type: 'code', product_name: 'istio', version: 'master' }]);
+    });
+
+    it('treats selecting every source as a full run', async () => {
+        const res = await triggerRun({ sources: [0, 1, 2, 3] });
+        expect(res.status).toBe(202);
+        expect(enqueue).toHaveBeenCalledWith(CONFIG, 'manual', undefined);
+    });
+
+    it('treats an empty selection as a full run', async () => {
+        const res = await triggerRun({ sources: [] });
+        expect(res.status).toBe(202);
+        expect(enqueue).toHaveBeenCalledWith(CONFIG, 'manual', undefined);
+    });
+
+    it('409s when the config changed since the client loaded the source list', async () => {
+        const res = await triggerRun({ sources: [0], baseHash: 'stale-hash' });
+        expect(res.status).toBe(409);
+        expect(enqueue).not.toHaveBeenCalled();
+    });
+
+    it('400s on out-of-range indices', async () => {
+        const res = await triggerRun({ sources: [0, 9] });
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error).toContain('9');
+        expect(enqueue).not.toHaveBeenCalled();
+    });
+
+    it('400s when sources is not an array of integers', async () => {
+        for (const sources of ['istio', ['istio'], [1.5]]) {
+            const res = await triggerRun({ sources });
+            expect(res.status).toBe(400);
+        }
+        expect(enqueue).not.toHaveBeenCalled();
+    });
+
+    it('404s for an unknown config', async () => {
+        const res = await fetch(`${baseUrl}/api/configs/99/run`, { method: 'POST' });
+        expect(res.status).toBe(404);
+    });
+});

--- a/tests/controller-store.test.ts
+++ b/tests/controller-store.test.ts
@@ -74,6 +74,22 @@ describe.skipIf(!TEST_DATABASE_URL)('ControllerStore (Postgres)', () => {
         expect((await store.listConfigs()).find(c => c.id === config.id)).toBeDefined();
     });
 
+    it('round-trips a manual source selection on runs', async () => {
+        const config = await store.upsertConfig({
+            path: '/test/store-sources.yaml', name: 'store-sources', content: 'x', contentHash: 'h',
+            schedule: null, sourceSummary: [], parseError: null,
+        });
+        const selection = [
+            { index: 1, product_name: 'istio', type: 'code', version: 'master' },
+            { index: 4, product_name: 'argo', type: 'website', version: 'latest' },
+        ];
+        const run = await store.createRun(config.id, 'h', 'manual', 'queued', undefined, selection);
+        expect(run.requested_sources).toEqual(selection);
+        expect((await store.getRun(run.id))!.requested_sources).toEqual(selection);
+        await store.finishRun(run.id, { status: 'succeeded', exitCode: 0 });
+        expect((await store.getRun(run.id))!.requested_sources).toEqual(selection);
+    });
+
     it('covers the run lifecycle and log paging', async () => {
         const config = await store.upsertConfig({
             path: '/test/store-c.yaml', name: 'store-c', content: 'x', contentHash: 'h',
@@ -82,6 +98,7 @@ describe.skipIf(!TEST_DATABASE_URL)('ControllerStore (Postgres)', () => {
 
         const run = await store.createRun(config.id, 'h', 'manual', 'queued');
         expect(run.status).toBe('queued');
+        expect(run.requested_sources).toBeNull();
 
         const started = await store.markRunStarted(run.id, 12345);
         expect(started.status).toBe('running');

--- a/tests/doc2vec.test.ts
+++ b/tests/doc2vec.test.ts
@@ -298,6 +298,71 @@ describe('Doc2Vec class', () => {
     });
 
     // ─────────────────────────────────────────────────────────────────────────
+    // 1b. run() source filter
+    // ─────────────────────────────────────────────────────────────────────────
+    describe('run source filter', () => {
+        function makeTwoSourceInstance() {
+            const config = {
+                sources: ['SiteA', 'SiteB'].map(name => ({
+                    type: 'website',
+                    product_name: name,
+                    version: '1.0',
+                    max_size: 50000,
+                    url: `https://example.com/${name}`,
+                    database_config: { type: 'sqlite', params: { db_path: ':memory:' } },
+                })),
+            };
+            const configPath = writeTestConfig('run-filter.yaml', config);
+            const instance = new Doc2Vec(configPath);
+            const processWebsite = vi.fn(async () => {});
+            (instance as any).processWebsite = processWebsite;
+            return { instance, processWebsite };
+        }
+
+        it('should only process the sources selected by name', async () => {
+            const { instance, processWebsite } = makeTwoSourceInstance();
+            const stats = await instance.run({ names: ['SiteB'] });
+            expect(processWebsite).toHaveBeenCalledTimes(1);
+            expect(processWebsite.mock.calls[0][0].product_name).toBe('SiteB');
+            expect(stats).toHaveLength(1);
+            expect(stats[0].product_name).toBe('SiteB');
+        });
+
+        it('should only process the sources selected by index', async () => {
+            const { instance, processWebsite } = makeTwoSourceInstance();
+            const stats = await instance.run({ indices: [0] });
+            expect(processWebsite).toHaveBeenCalledTimes(1);
+            expect(stats.map(s => s.product_name)).toEqual(['SiteA']);
+        });
+
+        it('should process the union of names and indices, in config order', async () => {
+            const { instance, processWebsite } = makeTwoSourceInstance();
+            const stats = await instance.run({ indices: [1], names: ['SiteA'] });
+            expect(processWebsite).toHaveBeenCalledTimes(2);
+            expect(stats.map(s => s.product_name)).toEqual(['SiteA', 'SiteB']);
+        });
+
+        it('should process all sources when no filter is given', async () => {
+            const { instance, processWebsite } = makeTwoSourceInstance();
+            const stats = await instance.run();
+            expect(processWebsite).toHaveBeenCalledTimes(2);
+            expect(stats.map(s => s.product_name)).toEqual(['SiteA', 'SiteB']);
+        });
+
+        it('should throw on unknown source names', async () => {
+            const { instance, processWebsite } = makeTwoSourceInstance();
+            await expect(instance.run({ names: ['SiteA', 'Nope'] })).rejects.toThrow(/Unknown source\(s\): Nope/);
+            expect(processWebsite).not.toHaveBeenCalled();
+        });
+
+        it('should throw on out-of-range source indices', async () => {
+            const { instance, processWebsite } = makeTwoSourceInstance();
+            await expect(instance.run({ indices: [5] })).rejects.toThrow(/index out of range: 5/);
+            expect(processWebsite).not.toHaveBeenCalled();
+        });
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
     // 2. loadConfig
     // ─────────────────────────────────────────────────────────────────────────
     describe('loadConfig', () => {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -18,6 +18,14 @@ export interface SourceRunCounters {
   chunks_deleted: number;
 }
 
+/** One config source entry targeted by a partial manual run. */
+export interface RequestedSource {
+  index: number;
+  product_name: string;
+  type: string;
+  version?: string;
+}
+
 export interface SourceRunStats {
   product_name: string;
   type: string;
@@ -37,6 +45,8 @@ export interface RunRecord {
   pid: number | null;
   exit_code: number | null;
   error: string | null;
+  /** Manual source selection; null = all sources */
+  requested_sources: RequestedSource[] | null;
   stats: {
     sources?: SourceRunStats[];
     warn_count?: number;
@@ -142,7 +152,11 @@ export const api = {
       '/api/configs/validate',
       { method: 'POST', body: JSON.stringify({ content }) }
     ),
-  triggerRun: (configId: number) => request<RunRecord>(`/api/configs/${configId}/run`, { method: 'POST' }),
+  triggerRun: (configId: number, sources?: number[], baseHash?: string) =>
+    request<RunRecord>(`/api/configs/${configId}/run`, {
+      method: 'POST',
+      ...(sources?.length ? { body: JSON.stringify({ sources, baseHash }) } : {}),
+    }),
   configStats: (configId: number, days: number) =>
     request<ConfigStats>(`/api/configs/${configId}/stats?days=${days}`),
   chunksForUrl: (configId: number, params: { product_name: string; type?: string; version?: string; url: string }) => {

--- a/ui/src/components/RunButton.tsx
+++ b/ui/src/components/RunButton.tsx
@@ -1,0 +1,180 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { api, ApiError, ConfigRecord } from '../api';
+
+/**
+ * Split "Run now" button: the main button syncs every source, the chevron opens
+ * a picker to run a subset of the config's source entries. Selection is by
+ * position in the config's sources list, so entries sharing a product name
+ * (e.g. istio as github + code + website) are selectable individually.
+ */
+export default function RunButton({ config, variant = 'subtle' }: {
+  config: ConfigRecord;
+  variant?: 'primary' | 'subtle';
+}) {
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [filter, setFilter] = useState('');
+
+  const mutation = useMutation({
+    mutationFn: (sources?: number[]) => api.triggerRun(config.id, sources, config.content_hash),
+    onSuccess: () => {
+      setOpen(false);
+      setSelected(new Set());
+      setFilter('');
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['configs'] }),
+  });
+
+  const entries = useMemo(
+    () => config.source_summary.map((source, index) => ({ ...source, index })),
+    [config.source_summary]
+  );
+  const visible = useMemo(() => {
+    const needle = filter.trim().toLowerCase();
+    if (!needle) return entries;
+    return entries.filter(e =>
+      e.product_name.toLowerCase().includes(needle) || e.type.toLowerCase().includes(needle)
+    );
+  }, [entries, filter]);
+
+  const disabled = config.busy || !!config.parse_error || mutation.isPending;
+
+  const stop = (e: React.SyntheticEvent) => {
+    // The dashboard renders this inside a <Link> card — keep clicks local
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  const toggle = (index: number) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
+  };
+
+  const allVisibleSelected = visible.length > 0 && visible.every(e => selected.has(e.index));
+  const toggleAllVisible = () => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (allVisibleSelected) visible.forEach(e => next.delete(e.index));
+      else visible.forEach(e => next.add(e.index));
+      return next;
+    });
+  };
+
+  const mainClass = variant === 'primary'
+    ? 'bg-accent text-white transition hover:opacity-90 px-3.5 py-1.5 text-sm font-medium'
+    : 'border border-edge bg-surface text-ink-secondary transition hover:border-accent hover:text-accent px-3 py-1 text-xs font-medium';
+  const chevronClass = variant === 'primary'
+    ? 'bg-accent text-white transition hover:opacity-90 border-l border-white/25 px-2 py-1.5 text-sm'
+    : 'border border-l-0 border-edge bg-surface text-ink-secondary transition hover:border-accent hover:text-accent px-1.5 py-1 text-xs';
+
+  return (
+    <div className="relative inline-flex items-center gap-2" onClick={stop}>
+      <span className="inline-flex">
+        <button
+          onClick={e => {
+            stop(e);
+            mutation.mutate(undefined);
+          }}
+          disabled={disabled}
+          className={`${entries.length > 1 ? 'rounded-l-md' : 'rounded-md'} ${mainClass} disabled:cursor-not-allowed disabled:opacity-40`}
+        >
+          {config.busy ? 'Running…' : 'Run now'}
+        </button>
+        {entries.length > 1 && (
+          <button
+            onClick={e => {
+              stop(e);
+              setOpen(o => !o);
+            }}
+            disabled={disabled}
+            aria-label="Choose sources to run"
+            title="Choose sources to run"
+            className={`rounded-r-md ${chevronClass} disabled:cursor-not-allowed disabled:opacity-40`}
+          >
+            ▾
+          </button>
+        )}
+      </span>
+
+      {mutation.error && (
+        <span className="text-xs text-critical">{(mutation.error as ApiError).message}</span>
+      )}
+
+      {open && (
+        <>
+          <div className="fixed inset-0 z-10" onClick={e => { stop(e); setOpen(false); }} />
+          <div className="absolute right-0 top-full z-20 mt-1.5 w-80 rounded-md border border-edge bg-surface shadow-lg">
+            <div className="flex items-center justify-between border-b border-edge px-3 py-2">
+              <span className="text-xs font-semibold uppercase tracking-wide text-ink-muted">
+                Run sources{selected.size > 0 && ` (${selected.size}/${entries.length})`}
+              </span>
+              <button
+                onClick={e => {
+                  stop(e);
+                  toggleAllVisible();
+                }}
+                className="text-xs text-accent hover:underline"
+              >
+                {allVisibleSelected ? 'Clear' : 'Select all'}{filter.trim() && ' shown'}
+              </button>
+            </div>
+            {entries.length > 8 && (
+              <div className="border-b border-edge px-3 py-2">
+                <input
+                  type="text"
+                  value={filter}
+                  onChange={e => setFilter(e.target.value)}
+                  onClick={e => e.stopPropagation()}
+                  placeholder="Filter sources…"
+                  className="w-full rounded-md border border-edge bg-page px-2 py-1 text-xs text-ink-secondary placeholder:text-ink-muted focus:border-accent focus:outline-none"
+                />
+              </div>
+            )}
+            <ul className="max-h-64 overflow-y-auto py-1">
+              {visible.map(entry => (
+                <li key={entry.index}>
+                  <label
+                    className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-ink-secondary hover:bg-edge/20"
+                    onClick={e => e.stopPropagation()}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selected.has(entry.index)}
+                      onChange={() => toggle(entry.index)}
+                      className="accent-accent"
+                    />
+                    <span className="truncate">{entry.product_name}</span>
+                    <span className="ml-auto shrink-0 text-xs text-ink-muted">
+                      {entry.type}{entry.version ? ` · ${entry.version}` : ''}
+                    </span>
+                  </label>
+                </li>
+              ))}
+              {visible.length === 0 && (
+                <li className="px-3 py-2 text-xs text-ink-muted">No sources match “{filter}”.</li>
+              )}
+            </ul>
+            <div className="border-t border-edge px-3 py-2">
+              <button
+                onClick={e => {
+                  stop(e);
+                  mutation.mutate([...selected]);
+                }}
+                disabled={selected.size === 0 || disabled}
+                className="w-full rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Run {selected.size > 0 ? `${selected.size} selected` : 'selected'} source{selected.size === 1 ? '' : 's'}
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/RunsTable.tsx
+++ b/ui/src/components/RunsTable.tsx
@@ -41,7 +41,17 @@ export default function RunsTable({ runs, showConfig = false, configNames }: {
                 </td>
               )}
               <td className="py-2.5 pr-4"><RunStatusBadge status={run.status} /></td>
-              <td className="py-2.5 pr-4 text-ink-secondary">{run.trigger}</td>
+              <td className="py-2.5 pr-4 text-ink-secondary">
+                {run.trigger}
+                {run.requested_sources && run.requested_sources.length > 0 && (
+                  <span
+                    className="ml-1.5 rounded-full border border-edge px-1.5 py-0.5 text-xs text-ink-muted"
+                    title={`Selected sources: ${run.requested_sources.map(s => `${s.product_name} (${s.type})`).join(', ')}`}
+                  >
+                    {run.requested_sources.length} source{run.requested_sources.length > 1 ? 's' : ''}
+                  </span>
+                )}
+              </td>
               <td className="py-2.5 pr-4 text-ink-secondary">{formatTime(run.started_at ?? run.queued_at)}</td>
               <td className="py-2.5 pr-4 text-ink-secondary">
                 {run.status === 'running' || run.status === 'queued' ? '…' : runDuration(run.started_at, run.finished_at)}

--- a/ui/src/pages/ConfigDetail.tsx
+++ b/ui/src/pages/ConfigDetail.tsx
@@ -5,6 +5,7 @@ import { api, ApiError } from '../api';
 import { formatTime, humanizeCron, relativeTime } from '../lib/format';
 import ConfigEditor from '../components/ConfigEditor';
 import ConfigForm from '../components/ConfigForm';
+import RunButton from '../components/RunButton';
 import RunsTable from '../components/RunsTable';
 import SourceBadges from '../components/SourceBadges';
 import StatsCharts from '../components/StatsCharts';
@@ -35,10 +36,6 @@ export default function ConfigDetail() {
     enabled: tab === 'stats',
   });
 
-  const trigger = useMutation({
-    mutationFn: () => api.triggerRun(configId),
-    onSettled: () => queryClient.invalidateQueries({ queryKey: ['configs'] }),
-  });
   const remove = useMutation({
     mutationFn: () => api.deleteConfig(configId),
     onSuccess: () => {
@@ -64,13 +61,7 @@ export default function ConfigDetail() {
             </span>
           )}
           <div className="ml-auto flex items-center gap-2">
-            <button
-              onClick={() => trigger.mutate()}
-              disabled={config.busy || !!config.parse_error || trigger.isPending}
-              className="rounded-md bg-accent px-3.5 py-1.5 text-sm font-medium text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              {config.busy ? 'Running…' : 'Run now'}
-            </button>
+            <RunButton config={config} variant="primary" />
             {readWrite && (
               <button
                 onClick={() => {
@@ -85,7 +76,6 @@ export default function ConfigDetail() {
             )}
           </div>
         </div>
-        {trigger.error && <p className="mt-2 text-sm text-critical">{(trigger.error as ApiError).message}</p>}
         {remove.error && <p className="mt-2 text-sm text-critical">{(remove.error as ApiError).message}</p>}
         <dl className="mt-3 flex flex-wrap gap-x-8 gap-y-2 text-sm">
           <div>

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,37 +1,12 @@
 import { useState } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { Link, useNavigate } from 'react-router-dom';
-import { api, ApiError, ConfigRecord } from '../api';
+import { api } from '../api';
 import { formatTime, humanizeCron, relativeTime, runDuration } from '../lib/format';
 import RunStatusBadge from '../components/RunStatusBadge';
 import ConfigForm from '../components/ConfigForm';
+import RunButton from '../components/RunButton';
 import SourceBadges from '../components/SourceBadges';
-
-function RunNowButton({ config }: { config: ConfigRecord }) {
-  const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: () => api.triggerRun(config.id),
-    onSettled: () => queryClient.invalidateQueries({ queryKey: ['configs'] }),
-  });
-  const disabled = config.busy || !!config.parse_error || mutation.isPending;
-  return (
-    <div className="flex items-center gap-2">
-      <button
-        onClick={e => {
-          e.preventDefault();
-          mutation.mutate();
-        }}
-        disabled={disabled}
-        className="rounded-md border border-edge bg-surface px-3 py-1 text-xs font-medium text-ink-secondary transition hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:opacity-40"
-      >
-        {config.busy ? 'Running…' : 'Run now'}
-      </button>
-      {mutation.error && (
-        <span className="text-xs text-critical">{(mutation.error as ApiError).message}</span>
-      )}
-    </div>
-  );
-}
 
 export default function Dashboard() {
   const navigate = useNavigate();
@@ -146,7 +121,7 @@ export default function Dashboard() {
                 </p>
               </div>
               <div className="md:self-center">
-                <RunNowButton config={config} />
+                <RunButton config={config} />
               </div>
             </div>
           </Link>

--- a/ui/src/pages/RunDetail.tsx
+++ b/ui/src/pages/RunDetail.tsx
@@ -1,9 +1,26 @@
+import { useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { api, ApiError } from '../api';
+import { api, ApiError, SourceRunStats } from '../api';
 import { formatDuration, formatTime, runDuration } from '../lib/format';
 import LogViewer from '../components/LogViewer';
 import RunStatusBadge from '../components/RunStatusBadge';
+
+type SourceSortKey = 'source' | 'type' | 'version' | 'duration' | 'changes' | 'result';
+
+function sourceSortValue(source: SourceRunStats, key: SourceSortKey): string | number {
+  switch (key) {
+    case 'source': return source.product_name;
+    case 'type': return source.type;
+    case 'version': return source.version ?? '';
+    case 'duration': return source.duration_ms;
+    case 'changes': {
+      const c = source.counters;
+      return c ? c.items_new + c.items_updated + c.items_deleted : -1;
+    }
+    case 'result': return source.ok ? 1 : 0;
+  }
+}
 
 export default function RunDetail() {
   const { id } = useParams();
@@ -23,11 +40,41 @@ export default function RunDetail() {
     onSettled: () => queryClient.invalidateQueries({ queryKey: ['runs', runId] }),
   });
 
+  const [sort, setSort] = useState<{ key: SourceSortKey; dir: 1 | -1 } | null>(null);
+  // Keep each source's original position: it's the key of the per-source detail
+  // route, which must not change when the table is re-sorted.
+  const sortedSources = useMemo(() => {
+    const rows = (run?.stats?.sources ?? []).map((source, index) => ({ source, index }));
+    if (!sort) return rows;
+    return [...rows].sort((a, b) => {
+      const va = sourceSortValue(a.source, sort.key);
+      const vb = sourceSortValue(b.source, sort.key);
+      const cmp = typeof va === 'string' && typeof vb === 'string' ? va.localeCompare(vb) : Number(va) - Number(vb);
+      return cmp * sort.dir;
+    });
+  }, [run, sort]);
+
   if (error) return <p className="text-critical">{(error as ApiError).message}</p>;
   if (!run) return <p className="text-ink-muted">Loading…</p>;
 
   const active = run.status === 'queued' || run.status === 'running';
-  const sources = run.stats?.sources ?? [];
+
+  // Clicking a header sorts ascending, again descending, a third time restores config order
+  const sortHeader = (label: string, key: SourceSortKey) => (
+    <th className="px-4 py-2 font-medium">
+      <button
+        onClick={() => setSort(prev =>
+          prev?.key !== key ? { key, dir: 1 } : prev.dir === 1 ? { key, dir: -1 } : null
+        )}
+        className={`inline-flex items-center gap-1 uppercase tracking-wide transition hover:text-ink-secondary ${
+          sort?.key === key ? 'text-ink-secondary' : ''
+        }`}
+      >
+        {label}
+        <span className="text-[10px]">{sort?.key === key ? (sort.dir === 1 ? '▲' : '▼') : ''}</span>
+      </button>
+    </th>
+  );
 
   return (
     <div className="space-y-6">
@@ -52,7 +99,7 @@ export default function RunDetail() {
         {cancel.error && <p className="mt-2 text-sm text-critical">{(cancel.error as ApiError).message}</p>}
         <dl className="mt-3 flex flex-wrap gap-x-8 gap-y-2 text-sm">
           {[
-            ['Trigger', run.trigger],
+            ['Trigger', run.requested_sources?.length ? `${run.trigger} (partial)` : run.trigger],
             ['Queued', formatTime(run.queued_at)],
             ['Started', formatTime(run.started_at)],
             ['Duration', active ? '…' : runDuration(run.started_at, run.finished_at)],
@@ -66,24 +113,37 @@ export default function RunDetail() {
             </div>
           ))}
         </dl>
+        {run.requested_sources && run.requested_sources.length > 0 && (
+          <p className="mt-2 text-sm text-ink-secondary">
+            <span className="text-xs uppercase tracking-wide text-ink-muted">Selected sources</span>{' '}
+            <span className="ml-1 inline-flex flex-wrap gap-1.5 align-middle">
+              {run.requested_sources.map(source => (
+                <span key={source.index} className="rounded-full border border-edge bg-page px-2 py-0.5 text-xs">
+                  {source.product_name}
+                  <span className="ml-1 text-ink-muted">{source.type}{source.version ? ` · ${source.version}` : ''}</span>
+                </span>
+              ))}
+            </span>
+          </p>
+        )}
       </div>
 
-      {sources.length > 0 && (
+      {sortedSources.length > 0 && (
         <div className="overflow-x-auto rounded-lg border border-edge bg-surface">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-edge text-left text-xs uppercase tracking-wide text-ink-muted">
-                <th className="px-4 py-2 font-medium">Source</th>
-                <th className="px-4 py-2 font-medium">Type</th>
-                <th className="px-4 py-2 font-medium">Version</th>
-                <th className="px-4 py-2 font-medium">Duration</th>
-                <th className="px-4 py-2 font-medium">Changes</th>
-                <th className="px-4 py-2 font-medium">Result</th>
+                {sortHeader('Source', 'source')}
+                {sortHeader('Type', 'type')}
+                {sortHeader('Version', 'version')}
+                {sortHeader('Duration', 'duration')}
+                {sortHeader('Changes', 'changes')}
+                {sortHeader('Result', 'result')}
                 <th className="px-4 py-2" />
               </tr>
             </thead>
             <tbody>
-              {sources.map((source, index) => (
+              {sortedSources.map(({ source, index }) => (
                 <tr
                   key={`${source.product_name}-${source.type}-${index}`}
                   onClick={() => navigate(`/runs/${run.id}/sources/${index}`)}


### PR DESCRIPTION
## What

- **Manual runs can target a subset of a config's sources.** The **Run now** button (dashboard + config page) is now a split button: the **▾** chevron opens a picker listing every source entry with a checkbox — entries sharing a product name (e.g. `istio` as github + code + website) are selectable individually. A filter box helps with large configs, and "Select all" applies to the filtered view.
- **Sortable per-source results table** on the run page: click any column header (Source, Type, Version, Duration, Changes, Result) to sort asc/desc; a third click restores config order. Row links to the per-source detail page stay correct while sorted.

## How

- Selection unit is the entry's 0-based position in the config's sources list — the only unambiguous identifier, since product names (even with type and version) can repeat.
- `POST /api/configs/:id/run` accepts `{ sources: [indices], baseHash }`; it 409s if the config changed since the client loaded the source list (indices would shift), 400s on invalid/out-of-range indices, and collapses empty/full selections into a normal full run.
- The runner spawns `doc2vec run <config> --source-index <n>...`; the resolved entries are persisted in a new `d2v_runs.requested_sources` JSONB column (migration 3), and shown as badges on the run page plus an "N sources" pill in run history.
- The CLI `run` subcommand also accepts `--source <product_name>` (repeatable) as a human-friendly form; `Doc2Vec.run()` takes the union of names and indices and validates both.
- Bug found while smoke-testing the built CLI: declaring the filter flags on the top-level command too made commander swallow them at the program level, silently ignoring the filter — the flags now live only on the `run` subcommand.

## Tests

- New `tests/controller-server-run.test.ts`: index resolution and ordering, same-name disambiguation, stale-hash 409, out-of-range/type validation, empty/full-selection collapse, 404.
- `Doc2Vec.run` selection by names, indices, their union, and both error paths.
- Runner: `--source-index` args on the spawned command and persistence on the run record.
- Full suite: 686 passed, 8 env-gated skips; verified against the built CLI that `--source-index 1` on a two-source config processes only the selected source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)