### PR TITLE
feat(code): skip files and directories matched by exclude_paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Configuration is managed through two files:
         *   `branch`: (Optional) Branch to clone for GitHub sources.
         *   `include_extensions`: (Optional) Array of file extensions to include (defaults to common code extensions).
         *   `exclude_extensions`: (Optional) Array of file extensions to exclude.
+        *   `exclude_paths`: (Optional) Array of glob patterns, relative to the source root, that the scanner skips. See [Excluding paths from code sources](#excluding-paths-from-code-sources).
         *   `recursive`: (Optional) Whether to traverse subdirectories (defaults to `true`).
         *   `url_rewrite_prefix`: (Optional) URL prefix to rewrite `file://` URLs for local sources.
         *   `encoding`: (Optional) File encoding to use (defaults to `'utf8'`).
@@ -359,6 +360,10 @@ Configuration is managed through two files:
         repo: 'kagent-dev/doc2vec'
         branch: 'main'
         include_extensions: ['.ts', '.tsx', '.md']
+        exclude_paths:
+          - 'node_modules/**'
+          - 'dist/**'
+          - '**/*.test.ts'
         max_size: 1048576
         chunk_size: 2048
         database_config:
@@ -414,6 +419,43 @@ Configuration is managed through two files:
             collection_name: 'istio_docs_latest'
       # ... more sources
     ```
+
+### Excluding paths from code sources
+
+Code sources (`type: 'code'`) accept `exclude_paths`. Each entry is a glob pattern that the scanner matches against the path of the file, relative to the source root. The root is the `path` directory for a local source, or the clone root for a GitHub source. Use it to keep vendored trees, generated code, and test files out of the index.
+
+```yaml
+      - type: 'code'
+        source: 'github'
+        product_name: 'my-product'
+        repo: 'my-org/my-repo'
+        branch: 'main'
+        include_extensions: ['.go', '.md', '.yaml', '.sh', '.py', '.proto']
+        exclude_paths:
+          - 'vendor/**'                 # vendored dependencies
+          - 'LICENSES/**'               # go-licenses output
+          - 'pkg/client/**'             # k8s code-generator output
+          - '**/*.pb.go'                # protobuf output
+          - '**/zz_generated.*.go'      # controller-gen output
+          - '**/*_test.go'              # tests
+          - 'hack/tools/**'
+        max_size: 1048576
+        database_config:
+          type: 'sqlite'
+          params:
+            db_path: './my-product-code.db'
+```
+
+Pattern rules:
+
+*   `*` matches any characters inside one path segment. It does not cross a `/`.
+*   `**` matches any characters, and it crosses `/`. `vendor/**` therefore matches every file below `vendor/`.
+*   A leading `**/` also matches zero directories, so `**/*_test.go` matches `main_test.go` at the root and `pkg/a/main_test.go` below it.
+*   `?` matches one character inside a segment.
+*   A pattern that names a directory (`vendor` or `vendor/**`) prunes the whole subtree. The scanner does not walk it.
+*   Matching is case-sensitive, and a pattern must match the whole relative path. Use `**/build/**`, not `build`, to exclude a directory at any depth.
+
+The scanner treats an excluded file as if it does not exist. A full scan therefore removes the chunks of files you newly excluded. For GitHub sources in incremental mode, the removal happens on the next full scan.
 
 ## Usage
 

--- a/content-processor.ts
+++ b/content-processor.ts
@@ -1819,6 +1819,10 @@ export class ContentProcessor {
             allowedFiles?: Set<string>;
             mtimeCutoff?: number;
             trackFiles?: Set<string>;
+            // The directory the scan started from. Recursive calls pass it down
+            // so `exclude_paths` patterns keep matching against the source root
+            // and not against the current subdirectory.
+            rootPath?: string;
         }
     ): Promise<CodeScanResult> {
         const logger = parentLogger.child('code-directory-processor');
@@ -1834,7 +1838,10 @@ export class ContentProcessor {
             '.json', '.yaml', '.yml', '.md'
         ];
         const excludeExtensions = config.exclude_extensions || [];
+        const excludePaths = config.exclude_paths || [];
         const encoding = config.encoding || ('utf8' as BufferEncoding);
+        const rootPath = options?.rootPath ?? dirPath;
+        const childOptions = { ...options, rootPath };
 
         let maxMtime = 0;
 
@@ -1872,6 +1879,22 @@ export class ContentProcessor {
 
                 visitedPaths.add(filePath);
 
+                // An excluded path never reaches trackFiles or maxMtime, so the
+                // caller treats it like a deleted file and removes its chunks
+                if (excludePaths.length > 0) {
+                    const relativePath = path.relative(rootPath, filePath).replace(/\\/g, '/');
+                    const excluded = stat.isDirectory()
+                        ? Utils.isDirectoryExcluded(relativePath, excludePaths)
+                        : Utils.matchesAnyGlob(relativePath, excludePaths);
+                    if (excluded) {
+                        logger.debug(`Skipping excluded path: ${relativePath}`);
+                        if (!stat.isDirectory()) {
+                            skippedFiles++;
+                        }
+                        continue;
+                    }
+                }
+
                 if (stat.isDirectory()) {
                     if (recursive) {
                         const childResult = await this.processCodeDirectory(
@@ -1880,7 +1903,7 @@ export class ContentProcessor {
                             processFileContent,
                             logger,
                             visitedPaths,
-                            options
+                            childOptions
                         );
                         processedFiles += childResult.processedFiles;
                         skippedFiles += childResult.skippedFiles;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "doc2vec",
-    "version": "2.13.1",
+    "version": "2.14.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "doc2vec",
-            "version": "2.13.1",
+            "version": "2.14.2",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.1004.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "doc2vec",
-    "version": "2.14.0",
+    "version": "2.14.2",
     "type": "commonjs",
     "description": "",
     "main": "dist/doc2vec.js",

--- a/tests/content-processor.test.ts
+++ b/tests/content-processor.test.ts
@@ -771,6 +771,200 @@ describe('ContentProcessor', () => {
         });
     });
 
+    // ─── processCodeDirectory: exclude_paths ────────────────────────
+    describe('processCodeDirectory with exclude_paths', () => {
+        const testDir = path.join(__dirname, '__test_exclude_dir__');
+
+        const codeConfig: CodeSourceConfig = {
+            type: 'code',
+            source: 'local_directory',
+            path: '',
+            product_name: 'Test',
+            version: '1.0',
+            max_size: 100000,
+            database_config: { type: 'sqlite', params: {} }
+        };
+
+        // Builds a small tree that looks like a Go repo with vendored and
+        // generated code:
+        //   main.go, main_test.go
+        //   api/types.pb.go, api/types.go, api/zz_generated.deepcopy.go
+        //   pkg/client/clientset.go
+        //   pkg/svc/svc.go, pkg/svc/svc_test.go
+        //   vendor/dep/dep.go
+        //   vendor.go
+        const writeTree = () => {
+            const files = [
+                'main.go',
+                'main_test.go',
+                'api/types.pb.go',
+                'api/types.go',
+                'api/zz_generated.deepcopy.go',
+                'pkg/client/clientset.go',
+                'pkg/svc/svc.go',
+                'pkg/svc/svc_test.go',
+                'vendor/dep/dep.go',
+                'vendor.go'
+            ];
+            for (const file of files) {
+                const target = path.join(testDir, file);
+                fs.mkdirSync(path.dirname(target), { recursive: true });
+                fs.writeFileSync(target, 'package main');
+            }
+        };
+
+        const scan = async (excludePaths: string[] | undefined, options?: Parameters<typeof processor.processCodeDirectory>[5]) => {
+            const processed: string[] = [];
+            const result = await processor.processCodeDirectory(
+                testDir,
+                { ...codeConfig, path: testDir, include_extensions: ['.go'], exclude_paths: excludePaths },
+                async (filePath) => { processed.push(filePath); },
+                testLogger,
+                undefined,
+                options
+            );
+            const relative = processed.map((filePath) => path.relative(testDir, filePath).replace(/\\/g, '/')).sort();
+            return { relative, result };
+        };
+
+        beforeEach(() => {
+            if (fs.existsSync(testDir)) {
+                fs.rmSync(testDir, { recursive: true });
+            }
+            fs.mkdirSync(testDir, { recursive: true });
+            writeTree();
+        });
+
+        afterEach(() => {
+            if (fs.existsSync(testDir)) {
+                fs.rmSync(testDir, { recursive: true });
+            }
+        });
+
+        it('processes every file when exclude_paths is absent', async () => {
+            const { relative } = await scan(undefined);
+
+            expect(relative).toEqual([
+                'api/types.go',
+                'api/types.pb.go',
+                'api/zz_generated.deepcopy.go',
+                'main.go',
+                'main_test.go',
+                'pkg/client/clientset.go',
+                'pkg/svc/svc.go',
+                'pkg/svc/svc_test.go',
+                'vendor.go',
+                'vendor/dep/dep.go'
+            ]);
+        });
+
+        it('prunes a directory subtree', async () => {
+            const { relative } = await scan(['vendor/**']);
+
+            expect(relative).not.toContain('vendor/dep/dep.go');
+            // a file whose name only starts with the pattern stays
+            expect(relative).toContain('vendor.go');
+        });
+
+        it('prunes a nested directory subtree', async () => {
+            const { relative } = await scan(['pkg/client/**']);
+
+            expect(relative).not.toContain('pkg/client/clientset.go');
+            expect(relative).toContain('pkg/svc/svc.go');
+        });
+
+        it('excludes files at any depth with a leading globstar', async () => {
+            const { relative } = await scan(['**/*_test.go']);
+
+            expect(relative).not.toContain('main_test.go');
+            expect(relative).not.toContain('pkg/svc/svc_test.go');
+            expect(relative).toContain('pkg/svc/svc.go');
+        });
+
+        it('excludes generated files by suffix and by name pattern', async () => {
+            const { relative } = await scan(['**/*.pb.go', '**/zz_generated.*.go']);
+
+            expect(relative).toEqual([
+                'main.go',
+                'main_test.go',
+                'pkg/client/clientset.go',
+                'pkg/svc/svc.go',
+                'pkg/svc/svc_test.go',
+                'vendor.go',
+                'vendor/dep/dep.go',
+                'api/types.go'
+            ].sort());
+        });
+
+        it('applies several patterns together', async () => {
+            const { relative, result } = await scan([
+                'vendor/**',
+                'pkg/client/**',
+                '**/*.pb.go',
+                '**/zz_generated.*.go',
+                '**/*_test.go'
+            ]);
+
+            expect(relative).toEqual(['api/types.go', 'main.go', 'pkg/svc/svc.go', 'vendor.go']);
+            expect(result.processedFiles).toBe(4);
+            expect(result.incomplete).toBe(false);
+        });
+
+        it('matches patterns against the source root, not the current subdirectory', async () => {
+            // 'client/**' names no directory at the root, so nothing is pruned;
+            // only 'pkg/client/**' removes the nested one
+            const { relative } = await scan(['client/**']);
+
+            expect(relative).toContain('pkg/client/clientset.go');
+        });
+
+        it('keeps excluded files out of trackFiles so the caller deletes their chunks', async () => {
+            const trackFiles = new Set<string>();
+            await scan(['vendor/**', '**/*_test.go'], { trackFiles });
+
+            const tracked = Array.from(trackFiles)
+                .map((filePath) => path.relative(testDir, filePath).replace(/\\/g, '/'))
+                .sort();
+            expect(tracked).toEqual([
+                'api/types.go',
+                'api/types.pb.go',
+                'api/zz_generated.deepcopy.go',
+                'main.go',
+                'pkg/client/clientset.go',
+                'pkg/svc/svc.go',
+                'vendor.go'
+            ]);
+        });
+
+        it('does not let an excluded file raise maxMtime', async () => {
+            const future = new Date(Date.now() + 60_000);
+            fs.utimesSync(path.join(testDir, 'vendor/dep/dep.go'), future, future);
+
+            const { result } = await scan(['vendor/**']);
+
+            expect(result.maxMtime).toBeLessThan(future.getTime());
+        });
+
+        it('counts an excluded file as skipped', async () => {
+            const { result } = await scan(['**/*_test.go']);
+
+            expect(result.processedFiles).toBe(8);
+            expect(result.skippedFiles).toBe(2);
+        });
+
+        it('reports a scan with exclusions as complete', async () => {
+            const { result } = await scan(['vendor/**']);
+
+            expect(result.incomplete).toBe(false);
+        });
+
+        it('ignores an empty pattern list', async () => {
+            const { relative } = await scan([]);
+
+            expect(relative).toContain('vendor/dep/dep.go');
+        });
+    });
+
     // ─── processDirectory: dangling symlinks ────────────────────────
     describe('processDirectory with a dangling symlink', () => {
         const testDir = path.join(__dirname, '__test_symlink_dir__');

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -476,4 +476,100 @@ describe('Utils', () => {
             expect((first + second).isWellFormed?.()).not.toBe(false);
         });
     });
+
+    // \u2500\u2500\u2500 matchesAnyGlob \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    describe('matchesAnyGlob', () => {
+        it('returns false for an empty pattern list', () => {
+            expect(Utils.matchesAnyGlob('vendor/a.go', [])).toBe(false);
+        });
+
+        it('matches an exact path', () => {
+            expect(Utils.matchesAnyGlob('go.mod', ['go.mod'])).toBe(true);
+            expect(Utils.matchesAnyGlob('pkg/go.mod', ['go.mod'])).toBe(false);
+        });
+
+        it('matches everything below a globstar directory', () => {
+            const patterns = ['vendor/**'];
+            expect(Utils.matchesAnyGlob('vendor/a.go', patterns)).toBe(true);
+            expect(Utils.matchesAnyGlob('vendor/x/y/z.go', patterns)).toBe(true);
+            expect(Utils.matchesAnyGlob('vendored/a.go', patterns)).toBe(false);
+            expect(Utils.matchesAnyGlob('pkg/vendor/a.go', patterns)).toBe(false);
+        });
+
+        it('matches a leading globstar at any depth, including the root', () => {
+            const patterns = ['**/*_test.go'];
+            expect(Utils.matchesAnyGlob('main_test.go', patterns)).toBe(true);
+            expect(Utils.matchesAnyGlob('pkg/a/main_test.go', patterns)).toBe(true);
+            expect(Utils.matchesAnyGlob('pkg/a/main.go', patterns)).toBe(false);
+        });
+
+        it('keeps a single star inside one path segment', () => {
+            const patterns = ['pkg/*.go'];
+            expect(Utils.matchesAnyGlob('pkg/a.go', patterns)).toBe(true);
+            expect(Utils.matchesAnyGlob('pkg/sub/a.go', patterns)).toBe(false);
+        });
+
+        it('matches a star in the middle of a name', () => {
+            const patterns = ['**/zz_generated.*.go'];
+            expect(Utils.matchesAnyGlob('api/v1/zz_generated.deepcopy.go', patterns)).toBe(true);
+            expect(Utils.matchesAnyGlob('api/v1/zz_generated.go', patterns)).toBe(false);
+        });
+
+        it('matches one character with a question mark', () => {
+            expect(Utils.matchesAnyGlob('v1/a.go', ['v?/a.go'])).toBe(true);
+            expect(Utils.matchesAnyGlob('v12/a.go', ['v?/a.go'])).toBe(false);
+        });
+
+        it('matches when any pattern in the list matches', () => {
+            const patterns = ['vendor/**', '**/*.pb.go'];
+            expect(Utils.matchesAnyGlob('api/v1/types.pb.go', patterns)).toBe(true);
+        });
+
+        it('treats a dot in the pattern as a literal', () => {
+            expect(Utils.matchesAnyGlob('axgo', ['a.go'])).toBe(false);
+        });
+
+        it('normalizes backslashes, leading ./ and trailing slashes', () => {
+            expect(Utils.matchesAnyGlob('vendor\\a.go', ['vendor/**'])).toBe(true);
+            expect(Utils.matchesAnyGlob('./vendor/a.go', ['./vendor/**'])).toBe(true);
+            expect(Utils.matchesAnyGlob('vendor', ['vendor/'])).toBe(true);
+        });
+
+        it('ignores an empty path or an empty pattern', () => {
+            expect(Utils.matchesAnyGlob('', ['**'])).toBe(false);
+            expect(Utils.matchesAnyGlob('a.go', [''])).toBe(false);
+        });
+
+        it('is case-sensitive', () => {
+            expect(Utils.matchesAnyGlob('Vendor/a.go', ['vendor/**'])).toBe(false);
+        });
+    });
+
+    // \u2500\u2500\u2500 isDirectoryExcluded \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    describe('isDirectoryExcluded', () => {
+        it('excludes a directory named by a globstar pattern', () => {
+            expect(Utils.isDirectoryExcluded('vendor', ['vendor/**'])).toBe(true);
+            expect(Utils.isDirectoryExcluded('pkg/client', ['pkg/client/**'])).toBe(true);
+        });
+
+        it('excludes a directory named directly', () => {
+            expect(Utils.isDirectoryExcluded('vendor', ['vendor'])).toBe(true);
+        });
+
+        it('excludes a nested directory that a globstar prefix matches', () => {
+            expect(Utils.isDirectoryExcluded('a/build', ['**/build/**'])).toBe(true);
+        });
+
+        it('does not exclude a directory when the pattern selects only some files', () => {
+            expect(Utils.isDirectoryExcluded('pkg', ['**/*_test.go'])).toBe(false);
+        });
+
+        it('does not exclude a parent of an excluded directory', () => {
+            expect(Utils.isDirectoryExcluded('pkg', ['pkg/client/**'])).toBe(false);
+        });
+
+        it('returns false for an empty pattern list', () => {
+            expect(Utils.isDirectoryExcluded('vendor', [])).toBe(false);
+        });
+    });
 });

--- a/types.ts
+++ b/types.ts
@@ -57,6 +57,7 @@ export interface CodeSourceConfig extends BaseSourceConfig {
     branch?: string;               // Optional branch to clone (github only)
     include_extensions?: string[]; // File extensions to include (e.g., ['.ts', '.py'])
     exclude_extensions?: string[]; // File extensions to exclude
+    exclude_paths?: string[];      // Glob patterns, relative to the source root, to skip (e.g., ['vendor/**', '**/*_test.go'])
     recursive?: boolean;           // Whether to traverse subdirectories
     encoding?: BufferEncoding;     // File encoding (default: 'utf8')
     url_rewrite_prefix?: string;   // Optional URL prefix to rewrite file:// URLs

--- a/ui/src/lib/config-schema.ts
+++ b/ui/src/lib/config-schema.ts
@@ -73,6 +73,7 @@ export const SOURCE_TYPES: Record<string, { label: string; fields: FieldDef[] }>
       { key: 'path', label: 'Directory path', type: 'string', placeholder: '/data/src', help: 'When source is local_directory' },
       { key: 'include_extensions', label: 'Include extensions', type: 'string_list', placeholder: '.ts, .go, .py' },
       { key: 'exclude_extensions', label: 'Exclude extensions', type: 'string_list' },
+      { key: 'exclude_paths', label: 'Exclude paths', type: 'string_list', placeholder: 'vendor/**, **/*_test.go', help: 'Glob patterns relative to the source root' },
       { key: 'recursive', label: 'Recurse into subdirectories', type: 'boolean' },
       { key: 'chunk_size', label: 'Chunk size (tokens)', type: 'number', placeholder: '1500' },
       { key: 'url_rewrite_prefix', label: 'URL rewrite prefix', type: 'string' },

--- a/utils.ts
+++ b/utils.ts
@@ -148,4 +148,87 @@ export class Utils {
         return text.slice(from, to);
     }
 
+    /**
+     * Normalize a glob pattern or a relative path to the form the matcher uses:
+     * forward slashes, no leading `./`, no leading or trailing `/`.
+     */
+    private static normalizeGlobPath(value: string): string {
+        return value
+            .replace(/\\/g, '/')
+            .replace(/^\.\//, '')
+            .replace(/^\/+/, '')
+            .replace(/\/+$/, '');
+    }
+
+    /**
+     * Build a regular expression from a glob pattern.
+     *
+     * `**` crosses directory separators, `*` and `?` do not. A globstar
+     * followed by a slash also matches zero directories, so a pattern like
+     * `**` + `/*_test.go` matches `main_test.go`
+     * at the root as well as `pkg/a/main_test.go`.
+     */
+    private static globToRegExp(pattern: string): RegExp {
+        let source = '';
+        let i = 0;
+        while (i < pattern.length) {
+            const char = pattern[i];
+            if (char === '*') {
+                let end = i;
+                while (pattern[end] === '*') end++;
+                const isGlobstar = end - i > 1;
+                if (!isGlobstar) {
+                    source += '[^/]*';
+                    i = end;
+                } else if (pattern[end] === '/') {
+                    source += '(?:.*/)?';
+                    i = end + 1;
+                } else {
+                    source += '.*';
+                    i = end;
+                }
+            } else if (char === '?') {
+                source += '[^/]';
+                i++;
+            } else {
+                source += char.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                i++;
+            }
+        }
+        return new RegExp(`^${source}$`);
+    }
+
+    /**
+     * Report whether a relative path matches one of the glob patterns.
+     */
+    static matchesAnyGlob(relativePath: string, patterns: string[]): boolean {
+        if (!patterns || patterns.length === 0) return false;
+        const normalizedPath = Utils.normalizeGlobPath(relativePath);
+        if (normalizedPath === '') return false;
+        return patterns.some((pattern) => {
+            const normalizedPattern = Utils.normalizeGlobPath(pattern);
+            if (normalizedPattern === '') return false;
+            return Utils.globToRegExp(normalizedPattern).test(normalizedPath);
+        });
+    }
+
+    /**
+     * Report whether a directory is excluded, so the caller can skip the whole
+     * subtree instead of walking it.
+     *
+     * A directory is excluded when a pattern matches the directory itself
+     * (`vendor`) or when a pattern excludes everything below it (`vendor/**`).
+     * Patterns that only select some descendants (a test-file pattern, for
+     * example) do not exclude the directory — the walk must continue and
+     * filter each file.
+     */
+    static isDirectoryExcluded(relativePath: string, patterns: string[]): boolean {
+        if (!patterns || patterns.length === 0) return false;
+        const prefixes = patterns
+            .map((pattern) => Utils.normalizeGlobPath(pattern))
+            .filter((pattern) => pattern.endsWith('/**'))
+            .map((pattern) => pattern.slice(0, -3));
+        return Utils.matchesAnyGlob(relativePath, patterns) || Utils.matchesAnyGlob(relativePath, prefixes);
+    }
+
 }


### PR DESCRIPTION
## Problem

Code sources can only filter by file extension. A repository with a large `vendor/` tree, generated clients, or protobuf output gets indexed whole. On one internal repo, `vendor/` alone is 92.9% of the bytes.

## Change

`CodeSourceConfig` gains `exclude_paths`: a list of glob patterns, relative to the source root. The root is the `path` directory for a local source, or the clone root for a GitHub source.

```yaml
- type: 'code'
  source: 'github'
  repo: 'my-org/my-repo'
  include_extensions: ['.go', '.md', '.yaml', '.sh', '.py', '.proto']
  exclude_paths:
    - 'vendor/**'                 # vendored dependencies
    - 'LICENSES/**'               # go-licenses output
    - 'pkg/client/**'             # k8s code-generator output
    - '**/*.pb.go'                # protobuf output
    - '**/zz_generated.*.go'      # controller-gen output
    - '**/*_test.go'              # tests
```

Pattern rules:

* `*` and `?` stay inside one path segment. `**` crosses `/`.
* A leading `**/` also matches zero directories, so `**/*_test.go` matches `main_test.go` at the root.
* A pattern that names a directory (`vendor` or `vendor/**`) prunes the whole subtree. The scanner never walks it.
* Matching is case-sensitive, and a pattern must match the whole relative path.

The check runs before the walker records the file in `trackFiles` or raises `maxMtime`. An excluded file therefore looks deleted to the caller, and a full scan removes its chunks.

The recursion carries the scan root in `options.rootPath`, so patterns keep matching against the source root and not against the current subdirectory.

## Scope

`exclude_paths` applies to code sources only (`type: 'code'`). Other source types are unchanged.

Known limit: for GitHub sources in incremental mode (git diff since the last SHA), chunks of newly excluded files are removed on the next full scan, not on the incremental run. The README states this.

## Files

* `types.ts` — the new field.
* `utils.ts` — `Utils.matchesAnyGlob()` and `Utils.isDirectoryExcluded()`.
* `content-processor.ts` — the check and the subtree pruning in `processCodeDirectory`.
* `ui/src/lib/config-schema.ts` — the "Exclude paths" field in the code source form.
* `README.md` — field docs, pattern rules, and an example.

## Tests

`npx vitest run tests/utils.test.ts tests/content-processor.test.ts` — 320 pass.

* 18 unit tests on the matchers: exact paths, globstar subtrees, root-level globstar match, single-star segment limits, `?`, case sensitivity, path normalization, empty inputs.
* 12 walker tests on a Go-like tree: subtree pruning, `**/*_test.go` at any depth, `**/*.pb.go` and `**/zz_generated.*.go`, several patterns together, root-relative matching, `trackFiles` omission, `maxMtime`, and the skipped-file count.

Note: 5 test files fail on this machine with a `better-sqlite3` `NODE_MODULE_VERSION` mismatch. They fail the same way on a clean checkout, so they are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ATXjUV8bKHdZb9BNZ5CX6